### PR TITLE
Add Windows driver CI and optional load tests

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -5,59 +5,166 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+  workflow_dispatch:
+    inputs:
+      run_driver_load_tests:
+        description: Run the x64 driver load test on a prepared self-hosted runner
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+  actions: read
+
+env:
+  CRTSYS_CONFIGURATION: Debug
+  CRTSYS_WINDOWS_SDK_VERSION: 10.0.22621.0
 
 jobs:
   build:
-    runs-on: ${{ matrix.os }}
+    name: Build ${{ matrix.project }} ${{ matrix.arch }}
+    runs-on: windows-2022
     strategy:
+      fail-fast: false
       matrix:
-        os: [windows-2019]
-
-    defaults:
-      run:
-        working-directory: test
+        include:
+          - project: app
+            arch: x86
+          - project: app
+            arch: x64
+          - project: app
+            arch: ARM64
+          - project: driver
+            arch: x64
+          - project: driver
+            arch: ARM64
 
     steps:
-    - uses: actions/checkout@v2
-      with:
-        submodules: true
+      - uses: actions/checkout@v4
 
-    - name: build app x86
-      shell: cmd
-      run: ..\build.bat app x86
-      working-directory: test
+      - name: Show toolchain
+        shell: pwsh
+        run: |
+          cmake --version
 
-    - name: build app x64
-      shell: cmd
-      run: ..\build.bat app x64
-      working-directory: test
+          $vswhere = "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe"
+          & $vswhere -latest -products * -property installationPath
 
-    - name: build app ARM
-      shell: cmd
-      run: ..\build.bat app ARM
-      working-directory: test
+          Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\Include" -Directory |
+            Select-Object -ExpandProperty Name
 
-    - name: build app ARM64
-      shell: cmd
-      run: ..\build.bat app ARM64
-      working-directory: test
+      - name: Build
+        shell: pwsh
+        run: |
+          $parameters = @{
+            Project = '${{ matrix.project }}'
+            Architecture = '${{ matrix.arch }}'
+            Configuration = '${{ env.CRTSYS_CONFIGURATION }}'
+            WindowsSdkVersion = '${{ env.CRTSYS_WINDOWS_SDK_VERSION }}'
+          }
 
-    - name: build driver x86
-      shell: cmd
-      run: ..\build.bat driver x86
-      working-directory: test
+          if ($parameters.Project -eq 'driver') {
+            $parameters.NoBreakpoint = $true
+          }
 
-    - name: build driver x64
-      shell: cmd
-      run: ..\build.bat driver x64
-      working-directory: test
+          ./scripts/ci/Build-CrtSys.ps1 @parameters
 
-    - name: build driver ARM
-      shell: cmd
-      run: ..\build.bat driver ARM
-      working-directory: test
+      - name: Test-sign driver
+        if: matrix.project == 'driver'
+        shell: pwsh
+        run: ./scripts/ci/TestSign-Driver.ps1 -DriverPath test\driver\build_${{ matrix.arch }}\Debug\crtsys_test.sys
 
-    - name: build driver ARM64
-      shell: cmd
-      run: ..\build.bat driver ARM64
-      working-directory: test
+      - name: Upload signed driver
+        if: matrix.project == 'driver'
+        uses: actions/upload-artifact@v4
+        with:
+          name: crtsys-test-driver-${{ matrix.arch }}
+          path: |
+            test/driver/build_${{ matrix.arch }}/Debug/crtsys_test.sys
+            test/driver/build_${{ matrix.arch }}/Debug/crtsys_test.pdb
+
+      - name: Upload x64 test app
+        if: matrix.project == 'app' && matrix.arch == 'x64'
+        uses: actions/upload-artifact@v4
+        with:
+          name: crtsys-test-app-x64
+          path: |
+            test/app/build_x64/Debug/crtsys_test_app.exe
+            test/app/build_x64/Debug/crtsys_test_app.pdb
+
+  driver-load-test-preflight:
+    name: Driver load test preflight
+    if: github.event_name == 'workflow_dispatch' && inputs.run_driver_load_tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    steps:
+      - name: Check for an online driver test runner
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REQUIRED_LABELS: 'self-hosted,windows,x64,crtsys-driver-test'
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import subprocess
+          import sys
+
+          required = set(os.environ["REQUIRED_LABELS"].split(","))
+          repository = os.environ["GITHUB_REPOSITORY"]
+          data = json.loads(subprocess.check_output([
+              "gh", "api", f"repos/{repository}/actions/runners"
+          ], text=True))
+
+          matches = []
+          for runner in data.get("runners", []):
+              labels = {label["name"] for label in runner.get("labels", [])}
+              if required.issubset(labels):
+                  matches.append(runner)
+
+          online = [runner for runner in matches if runner.get("status") == "online"]
+          if not online:
+              print(
+                  "::error::No online self-hosted runner has labels "
+                  f"{sorted(required)}. Prepare a Windows x64 runner with "
+                  "TESTSIGNING enabled and the crtsys-driver-test label."
+              )
+              sys.exit(1)
+
+          for runner in online:
+              print(f"Using runner candidate: {runner['name']} ({runner['status']})")
+          PY
+
+  driver-load-test:
+    name: Driver load test x64
+    if: github.event_name == 'workflow_dispatch' && inputs.run_driver_load_tests
+    needs:
+      - build
+      - driver-load-test-preflight
+    # Add the crtsys-driver-test label only to a self-hosted Windows x64 runner
+    # that has TESTSIGNING enabled before boot.
+    runs-on: [self-hosted, windows, x64, crtsys-driver-test]
+    timeout-minutes: 30
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download signed x64 driver
+        uses: actions/download-artifact@v4
+        with:
+          name: crtsys-test-driver-x64
+          path: artifacts/driver-x64
+
+      - name: Download x64 test app
+        uses: actions/download-artifact@v4
+        with:
+          name: crtsys-test-app-x64
+          path: artifacts/app-x64
+
+      - name: Load driver and run unit tests
+        shell: pwsh
+        run: >
+          ./scripts/ci/Run-DriverTests.ps1
+          -DriverPath artifacts\driver-x64\crtsys_test.sys
+          -AppPath artifacts\app-x64\crtsys_test_app.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,20 @@ project(
 option(CRTSYS_NTL_MAIN      "Set to ON to use ntl::main" ON)
 option(CRTSYS_USE_LIBCNTPR  "Set to ON to use libcntpr" ON)
 
+function(crtsys_scope_compile_options_to_c_cxx TARGET_NAME)
+  get_target_property(TARGET_COMPILE_OPTIONS ${TARGET_NAME} COMPILE_OPTIONS)
+  if(NOT TARGET_COMPILE_OPTIONS)
+    return()
+  endif()
+
+  set(SCOPED_COMPILE_OPTIONS)
+  foreach(COMPILE_OPTION IN LISTS TARGET_COMPILE_OPTIONS)
+    list(APPEND SCOPED_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:C,CXX>:${COMPILE_OPTION}>")
+  endforeach()
+
+  set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_OPTIONS "${SCOPED_COMPILE_OPTIONS}")
+endfunction()
+
 # x64 is always set to use libcntpr. (_NLG_Notify, _NLG_Return2)
 if ("${CMAKE_VS_PLATFORM_NAME}" STREQUAL "x64")
   set(CRTSYS_USE_LIBCNTPR ON)
@@ -126,6 +140,7 @@ wdk_add_library(
     STATIC
     ${SOURCE_FILES}
     )
+crtsys_scope_compile_options_to_c_cxx(crtsys)
 
 #
 # Add include directories
@@ -179,25 +194,25 @@ endif()
 # Forced Include File
 #
 if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/include/.internal/winsdk/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/wdk/${WDK_VERSION}/forced.h")
-  target_compile_options(crtsys PRIVATE /FI"${CMAKE_CURRENT_SOURCE_DIR}/include/.internal/winsdk/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/wdk/${WDK_VERSION}/forced.h")
+  target_compile_options(crtsys PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/FI${CMAKE_CURRENT_SOURCE_DIR}/include/.internal/winsdk/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/wdk/${WDK_VERSION}/forced.h>")
 endif()
-target_compile_options(crtsys PRIVATE /FI"${CMAKE_CURRENT_SOURCE_DIR}/src/crtsys.h")
+target_compile_options(crtsys PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/FI${CMAKE_CURRENT_SOURCE_DIR}/src/crtsys.h>")
 if (UCXXRT_ENABLED)
-  target_compile_options(crtsys PRIVATE /FI"${ucxxrt_SOURCE_DIR}/ucxxrt.inl")
+  target_compile_options(crtsys PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/FI${ucxxrt_SOURCE_DIR}/ucxxrt.inl>")
 endif()
 
 #
 # TLS isn't supported yet.
 #
-target_compile_options(crtsys PUBLIC /Zc:threadSafeInit-)
+target_compile_options(crtsys PUBLIC "$<$<COMPILE_LANGUAGE:CXX>:/Zc:threadSafeInit->")
 
-target_compile_options(crtsys PUBLIC "/MT") # "/MT$<$<CONFIG:Debug>:d>"
+target_compile_options(crtsys PUBLIC "$<$<COMPILE_LANGUAGE:C,CXX>:/MT>") # "/MT$<$<CONFIG:Debug>:d>"
 # [not working] set_property(TARGET crtsys PROPERTY MSVC_RUNTIME_LIBRARY "MultiThreaded$<$<CONFIG:Debug>:Debug>")
 
 #
 # Generate Debug Info
 #
-target_compile_options(crtsys PUBLIC "$<$<CONFIG:Release>:/Zi>")
+target_compile_options(crtsys PUBLIC "$<$<AND:$<CONFIG:Release>,$<COMPILE_LANGUAGE:C,CXX>>:/Zi>")
 target_link_options(crtsys PUBLIC "$<$<CONFIG:Release>:/DEBUG>")
 
 #

--- a/README.md
+++ b/README.md
@@ -217,6 +217,9 @@ If the SDK and WDK versions are different, builds are more likely to fail. **If 
 
 ## Build & Test
 
+CI driver load tests are documented in
+[CI driver load tests](./docs/ci-driver-load-tests.md).
+
 1. Please build the library and test code by executing the command below.
 
     ```Batch

--- a/cmake/CrtSys.cmake
+++ b/cmake/CrtSys.cmake
@@ -4,6 +4,20 @@ cmake_policy(SET CMP0021 OLD)
 set(CMAKE_CXX_STANDARD_LIBRARIES " ")
 set(CMAKE_C_STANDARD_LIBRARIES ${CMAKE_CXX_STANDARD_LIBRARIES})
 
+function(crtsys_scope_compile_options_to_c_cxx TARGET_NAME)
+    get_target_property(TARGET_COMPILE_OPTIONS ${TARGET_NAME} COMPILE_OPTIONS)
+    if(NOT TARGET_COMPILE_OPTIONS)
+        return()
+    endif()
+
+    set(SCOPED_COMPILE_OPTIONS)
+    foreach(COMPILE_OPTION IN LISTS TARGET_COMPILE_OPTIONS)
+        list(APPEND SCOPED_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:C,CXX>:${COMPILE_OPTION}>")
+    endforeach()
+
+    set_target_properties(${TARGET_NAME} PROPERTIES COMPILE_OPTIONS "${SCOPED_COMPILE_OPTIONS}")
+endfunction()
+
 # Remove Runtime Checks
 string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 string(REGEX REPLACE "/RTC(su|[1su])" "" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")
@@ -46,6 +60,7 @@ find_package(WDK REQUIRED)
 function(crtsys_add_driver _target)
     cmake_parse_arguments(WDK "" "WINVER" "" ${ARGN})
     wdk_add_driver(${_target} ${WDK_UNPARSED_ARGUMENTS} CUSTOM_ENTRY_POINT CrtSysDriverEntry EXTENDED_CPP_FEATURES)
+    crtsys_scope_compile_options_to_c_cxx(${_target})
 
     target_link_libraries(${_target} crtsys)
 
@@ -53,10 +68,10 @@ function(crtsys_add_driver _target)
     set_property(TARGET ${_target} PROPERTY INCLUDE_DIRECTORIES "${crtsys_SOURCE_DIR}/include;${crtsys_SOURCE_DIR}/include/.internal/msvc/$(VCToolsVersion);${crtsys_SOURCE_DIR}/include/.internal/msvc/${MSVC_TOOLSET_VERSION};${crtsys_SOURCE_DIR}/include/.internal/msvc/$(VCToolsVersion)/stl;${crtsys_SOURCE_DIR}/include/.internal/msvc/${MSVC_TOOLSET_VERSION}/stl;$(VC_IncludePath);$(WindowsSDK_IncludePath);${INC_DIR_TMP}")
 
     if(EXISTS "${crtsys_SOURCE_DIR}/include/.internal/winsdk/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/wdk/${WDK_VERSION}/forced.h")
-      target_compile_options(${_target} PRIVATE /FI"${crtsys_SOURCE_DIR}/include/.internal/winsdk/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/wdk/${WDK_VERSION}/forced.h")
+      target_compile_options(${_target} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/FI${crtsys_SOURCE_DIR}/include/.internal/winsdk/${CMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION}/wdk/${WDK_VERSION}/forced.h>")
     endif()
 
-    target_compile_options(${_target} PRIVATE /FI"${crtsys_SOURCE_DIR}/include/.internal/adjust_link_order")
+    target_compile_options(${_target} PRIVATE "$<$<COMPILE_LANGUAGE:C,CXX>:/FI${crtsys_SOURCE_DIR}/include/.internal/adjust_link_order>")
 
     if(CRTSYS_NTL_MAIN)
       target_compile_definitions(${_target} PUBLIC CRTSYS_USE_NTL_MAIN)

--- a/docs/ci-driver-load-tests.md
+++ b/docs/ci-driver-load-tests.md
@@ -1,0 +1,94 @@
+# CI driver load tests
+
+The `CMake` workflow has two layers:
+
+1. GitHub-hosted `windows-2022` runners build the test app, build the x64 and
+   ARM64 drivers, test-sign the drivers, and upload artifacts.
+2. When `workflow_dispatch` is run with `run_driver_load_tests=true`, a
+   prepared self-hosted Windows runner downloads those artifacts, loads the
+   signed driver, and runs the x64 test app.
+
+This split keeps the build reproducible on GitHub-hosted runners while keeping
+kernel driver loading on a machine that was explicitly configured for it.
+
+## Runner requirements
+
+Prepare a Windows x64 machine or VM with:
+
+- GitHub Actions self-hosted runner registered to this repository.
+- Runner labels: `self-hosted`, `windows`, `x64`, `crtsys-driver-test`.
+- The runner process running elevated, or installed as a service account that
+  can create and start kernel driver services.
+- Test signing enabled before boot.
+- Secure Boot disabled when it prevents enabling test signing.
+
+The self-hosted runner does not need Visual Studio, CMake, or the WDK for the
+load-test job. The workflow downloads the already-built artifacts from the same
+run.
+
+The load-test job is x64 because kernel drivers must match the test machine's
+kernel architecture. Testing ARM64 drivers requires a separate Windows ARM64
+self-hosted runner and matching ARM64 test app pipeline. Testing x86 drivers
+requires a 32-bit Windows test machine; x86 kernel drivers cannot be loaded on
+x64 Windows.
+
+## Enable test signing
+
+Run these commands from an elevated PowerShell prompt on the runner machine:
+
+```powershell
+bcdedit /set testsigning on
+```
+
+Reboot the machine, then verify:
+
+```powershell
+bcdedit /enum '{current}'
+```
+
+The output should contain `testsigning Yes` or `testsigning on`.
+
+## Register the runner
+
+Create a new self-hosted runner in GitHub:
+
+```text
+Repository -> Settings -> Actions -> Runners -> New self-hosted runner
+```
+
+Use the GitHub-provided commands for Windows. When configuring the runner, add
+the custom label:
+
+```powershell
+.\config.cmd --url https://github.com/ntoskrnl7/crtsys --token <token> --labels crtsys-driver-test
+```
+
+Install it as a service if you want it to survive reboots:
+
+```powershell
+.\svc install
+.\svc start
+```
+
+Confirm the runner appears online in GitHub before triggering the load test.
+
+## Run the load test
+
+Open the `CMake` workflow in GitHub Actions, select `Run workflow`, and set:
+
+```text
+run_driver_load_tests = true
+```
+
+The workflow will:
+
+- Run a preflight check for an online runner with the required labels.
+- Build and upload `crtsys-test-driver-x64`.
+- Build and upload `crtsys-test-driver-ARM64`.
+- Build and upload `crtsys-test-app-x64`.
+- Download those artifacts on the self-hosted runner.
+- Create a temporary `CrtSysTest` kernel service.
+- Start the driver, run `crtsys_test_app.exe`, then stop and delete the service.
+
+If the test fails before loading the driver, check that the runner is elevated
+and that `bcdedit /enum '{current}'` reports test signing enabled.

--- a/scripts/ci/Build-CrtSys.ps1
+++ b/scripts/ci/Build-CrtSys.ps1
@@ -1,0 +1,63 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('app', 'driver')]
+  [string] $Project,
+
+  [Parameter(Mandatory = $true)]
+  [ValidateSet('x86', 'x64', 'ARM', 'ARM64')]
+  [string] $Architecture,
+
+  [ValidateSet('Debug', 'Release', 'RelWithDebInfo', 'MinSizeRel')]
+  [string] $Configuration = 'Debug',
+
+  [string] $WindowsSdkVersion = '10.0.22621.0',
+
+  [switch] $NoBreakpoint
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$sourceDir = Join-Path $repoRoot "test\$Project"
+
+if (-not (Test-Path (Join-Path $sourceDir 'CMakeLists.txt'))) {
+  throw "CMakeLists.txt was not found under '$sourceDir'."
+}
+
+$platformByArchitecture = @{
+  x86 = 'Win32'
+  x64 = 'x64'
+  ARM = 'ARM'
+  ARM64 = 'ARM64'
+}
+
+$platform = $platformByArchitecture[$Architecture]
+$buildDir = Join-Path $sourceDir "build_$Architecture"
+
+$configureArgs = @(
+  '-S', $sourceDir,
+  '-B', $buildDir,
+  '-G', 'Visual Studio 17 2022',
+  '-A', $platform,
+  '-T', 'host=x64',
+  "-DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion",
+  "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=$WindowsSdkVersion",
+  '-DCMAKE_CXX_FLAGS=/MP'
+)
+
+if ($Project -eq 'driver' -and $NoBreakpoint) {
+  $configureArgs += '-DCRTSYS_TEST_BREAKPOINT=OFF'
+}
+
+Write-Host "Configuring $Project $Architecture $Configuration with Windows SDK $WindowsSdkVersion"
+& cmake @configureArgs
+if ($LASTEXITCODE -ne 0) {
+  throw "CMake configure failed with exit code $LASTEXITCODE."
+}
+
+Write-Host "Building $Project $Architecture $Configuration"
+& cmake --build $buildDir --config $Configuration --parallel
+if ($LASTEXITCODE -ne 0) {
+  throw "CMake build failed with exit code $LASTEXITCODE."
+}

--- a/scripts/ci/Run-DriverTests.ps1
+++ b/scripts/ci/Run-DriverTests.ps1
@@ -1,0 +1,79 @@
+param(
+  [string] $DriverPath = 'test\driver\build_x64\Debug\crtsys_test.sys',
+  [string] $AppPath = 'test\app\build_x64\Debug\crtsys_test_app.exe',
+  [string] $ServiceName = 'CrtSysTest'
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Assert-Administrator {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = [Security.Principal.WindowsPrincipal]::new($identity)
+  if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    throw 'Driver load tests must run from an elevated self-hosted runner service.'
+  }
+}
+
+function Assert-TestSigningEnabled {
+  $bcdOutput = & bcdedit.exe /enum '{current}' 2>&1
+  if ($LASTEXITCODE -ne 0) {
+    throw "bcdedit failed: $($bcdOutput -join [Environment]::NewLine)"
+  }
+
+  $testSigningLine = $bcdOutput | Where-Object { $_ -match '^\s*testsigning\s+' } | Select-Object -First 1
+  if (-not $testSigningLine -or $testSigningLine -notmatch '(?i)\b(yes|on|true)\b') {
+    throw 'TESTSIGNING is not enabled. Run "bcdedit /set TESTSIGNING ON", disable Secure Boot if needed, reboot, and retry on this self-hosted runner.'
+  }
+}
+
+function Invoke-Sc {
+  param(
+    [Parameter(Mandatory = $true)]
+    [string[]] $Arguments,
+
+    [switch] $AllowFailure
+  )
+
+  & sc.exe @Arguments
+  $exitCode = $LASTEXITCODE
+  if ($exitCode -ne 0 -and -not $AllowFailure) {
+    throw "sc.exe $($Arguments -join ' ') failed with exit code $exitCode."
+  }
+  return $exitCode
+}
+
+Assert-Administrator
+Assert-TestSigningEnabled
+
+$resolvedDriverPath = (Resolve-Path $DriverPath).Path
+$resolvedAppPath = (Resolve-Path $AppPath).Path
+
+$queryExitCode = Invoke-Sc -Arguments @('query', $ServiceName) -AllowFailure
+if ($queryExitCode -eq 0) {
+  Invoke-Sc -Arguments @('stop', $ServiceName) -AllowFailure | Out-Null
+  Start-Sleep -Seconds 2
+  Invoke-Sc -Arguments @('delete', $ServiceName) -AllowFailure | Out-Null
+  Start-Sleep -Seconds 2
+}
+
+try {
+  Invoke-Sc -Arguments @(
+    'create', $ServiceName,
+    'type=', 'kernel',
+    'start=', 'demand',
+    'binPath=', $resolvedDriverPath,
+    'DisplayName=', 'crtsys test'
+  ) | Out-Null
+
+  Invoke-Sc -Arguments @('start', $ServiceName) | Out-Null
+
+  & $resolvedAppPath
+  if ($LASTEXITCODE -ne 0) {
+    throw "crtsys_test_app.exe failed with exit code $LASTEXITCODE."
+  }
+} finally {
+  Invoke-Sc -Arguments @('stop', $ServiceName) -AllowFailure | Out-Null
+  Start-Sleep -Seconds 2
+  Invoke-Sc -Arguments @('delete', $ServiceName) -AllowFailure | Out-Null
+}

--- a/scripts/ci/TestSign-Driver.ps1
+++ b/scripts/ci/TestSign-Driver.ps1
@@ -1,0 +1,74 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string] $DriverPath,
+
+  [string] $CertificateSubject = 'CN=crtsys CI Test Signing',
+
+  [string] $WorkDir = (Join-Path $PWD 'artifacts\test-signing')
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function Find-SignTool {
+  $kitsRoot = Join-Path ${env:ProgramFiles(x86)} 'Windows Kits\10\bin'
+  if (Test-Path $kitsRoot) {
+    $candidate = Get-ChildItem -Path $kitsRoot -Recurse -Filter signtool.exe |
+      Where-Object { $_.FullName -match '\\x64\\signtool\.exe$' } |
+      Sort-Object FullName -Descending |
+      Select-Object -First 1
+
+    if ($candidate) {
+      return $candidate.FullName
+    }
+  }
+
+  $fromPath = Get-Command signtool.exe -ErrorAction SilentlyContinue
+  if ($fromPath) {
+    return $fromPath.Source
+  }
+
+  throw 'signtool.exe was not found. Install the Windows Driver Kit on this machine.'
+}
+
+$resolvedDriverPath = (Resolve-Path $DriverPath).Path
+New-Item -ItemType Directory -Force -Path $WorkDir | Out-Null
+
+$passwordText = ([guid]::NewGuid().ToString('N') + [guid]::NewGuid().ToString('N'))
+$password = ConvertTo-SecureString -String $passwordText -Force -AsPlainText
+
+$cert = New-SelfSignedCertificate `
+  -Type CodeSigningCert `
+  -Subject $CertificateSubject `
+  -CertStoreLocation Cert:\CurrentUser\My `
+  -KeyExportPolicy Exportable `
+  -KeyUsage DigitalSignature `
+  -HashAlgorithm SHA256 `
+  -NotAfter (Get-Date).AddDays(7)
+
+try {
+  $pfxPath = Join-Path $WorkDir 'crtsys-test-signing.pfx'
+  $cerPath = Join-Path $WorkDir 'crtsys-test-signing.cer'
+
+  Export-PfxCertificate -Cert $cert -FilePath $pfxPath -Password $password | Out-Null
+  Export-Certificate -Cert $cert -FilePath $cerPath | Out-Null
+
+  $signTool = Find-SignTool
+
+  Write-Host "Test-signing $resolvedDriverPath"
+  & $signTool sign /v /fd SHA256 /f $pfxPath /p $passwordText $resolvedDriverPath
+  if ($LASTEXITCODE -ne 0) {
+    throw "signtool failed with exit code $LASTEXITCODE."
+  }
+
+  $signature = Get-AuthenticodeSignature $resolvedDriverPath
+  if (-not $signature.SignerCertificate) {
+    throw "The driver does not contain an Authenticode signature."
+  }
+
+  Write-Host "Signed by $($signature.SignerCertificate.Subject)"
+} finally {
+  if ($cert) {
+    Remove-Item -Path "Cert:\CurrentUser\My\$($cert.Thumbprint)" -ErrorAction SilentlyContinue
+  }
+}

--- a/src/custom/crt/math/fpclassify.c
+++ b/src/custom/crt/math/fpclassify.c
@@ -31,4 +31,12 @@ _Check_return_ _ACRTIMP short __cdecl _dclass(_In_ double _X);
 _Check_return_ _ACRTIMP short __cdecl _dclass(_In_ double _X) {
   return _dtest(&_X);
 }
+
+#if _MSC_VER >= 1920
+_Check_return_ _ACRTIMP short __cdecl _ldtest(_In_ long double *_Px);
+#pragma function(_ldtest)
+#endif
+_Check_return_ _ACRTIMP short __cdecl _ldtest(_In_ long double *_Px) {
+  return _dtest((double *)_Px);
+}
 #pragma warning(pop)

--- a/src/custom/crt/misc.c
+++ b/src/custom/crt/misc.c
@@ -67,6 +67,11 @@ _Check_return_ _ACRTIMP int __cdecl _fdsign(_In_ float _X)
     return _FSIGN_C(_X);
 }
 
+_Check_return_ _ACRTIMP long long __cdecl llabs(_In_ long long _X)
+{
+    return _X < 0 ? -_X : _X;
+}
+
 
 
 //

--- a/src/custom/misc/misc.cpp
+++ b/src/custom/misc/misc.cpp
@@ -14,6 +14,17 @@ extern "C" unsigned char _guard_xfg_dispatch_icall_nop = 0x90;
 
 #include <windows.h>
 
+#if defined(_WIN64)
+#define CRTSYS_DEFAULT_SECURITY_COOKIE ((UINT_PTR)0x00002B992DDFA232)
+#else
+#define CRTSYS_DEFAULT_SECURITY_COOKIE ((UINT_PTR)0xBB40E64E)
+#endif
+
+extern "C" DECLSPEC_SELECTANY UINT_PTR
+    __security_cookie = CRTSYS_DEFAULT_SECURITY_COOKIE;
+extern "C" DECLSPEC_SELECTANY UINT_PTR
+    __security_cookie_complement = ~CRTSYS_DEFAULT_SECURITY_COOKIE;
+
 #define _ROAPI_
 #include <roapi.h>
 

--- a/src/custom/misc/winapi.cpp
+++ b/src/custom/misc/winapi.cpp
@@ -13,6 +13,32 @@ EXTERN_C_START
 //
 
 WINBASEAPI
+BOOL
+WINAPI
+VerifyVersionInfoW (
+    _Inout_ PVOID lpVersionInformation,
+    _In_ DWORD dwTypeMask,
+    _In_ DWORDLONG dwlConditionMask
+    )
+{
+    if (lpVersionInformation == NULL) {
+        SetLastError( ERROR_INVALID_PARAMETER );
+        return FALSE;
+    }
+
+    NTSTATUS Status = RtlVerifyVersionInfo(
+        reinterpret_cast<PRTL_OSVERSIONINFOEXW>( lpVersionInformation ),
+        dwTypeMask,
+        dwlConditionMask );
+    if (! NT_SUCCESS( Status )) {
+        SetLastError( RtlNtStatusToDosError( Status ) );
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
+WINBASEAPI
 DWORD
 WINAPI
 GetTempPathA (

--- a/src/custom/msvc/143/crt/src/misc/cfg_support.inc
+++ b/src/custom/msvc/143/crt/src/misc/cfg_support.inc
@@ -1,6 +1,7 @@
 #pragma once
 
 
+EXTERN_C PVOID __guard_check_icall_fptr;
 
 
 

--- a/src/custom/winsdk/include/um/crtsys/WinBase.h
+++ b/src/custom/winsdk/include/um/crtsys/WinBase.h
@@ -9,6 +9,22 @@
 #include "fileapi.h"
 #include "processthreadsapi.h"
 
+EXTERN_C_START
+
+WINBASEAPI
+BOOL
+WINAPI
+VerifyVersionInfoW(
+    _Inout_ PVOID lpVersionInformation,
+    _In_ DWORD dwTypeMask,
+    _In_ DWORDLONG dwlConditionMask
+    );
+
+#ifndef VerifyVersionInfo
+#define VerifyVersionInfo VerifyVersionInfoW
+#endif
+
+EXTERN_C_END
 
 
 #define OFS_MAXPATHNAME 128

--- a/src/custom/winsdk/include/um/crtsys/Windows.h
+++ b/src/custom/winsdk/include/um/crtsys/Windows.h
@@ -10,6 +10,7 @@
 
 // winbase.h
 #include <wincontypes.h> // consoleapi.h 
+#include "WinBase.h"
 #include "fileapi.h"
 #include "synchapi.h"
 #include "processthreadsapi.h"

--- a/src/vcruntime.props
+++ b/src/vcruntime.props
@@ -73,6 +73,7 @@
   <!-- BufferOverflowK.lib(gs_support.obj) __security_cookie -->
   <ItemGroup>  
     <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\gs_cookie.c">
+      <ExcludedFromBuild>true</ExcludedFromBuild>
       <CompileAs>CompileAsC</CompileAs>
     </ClCompile>
     <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\gs_support.c">
@@ -149,7 +150,9 @@
   <ItemGroup>
     <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\app_appinit.cpp" />
     <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\argv_mode.cpp" />
-    <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\checkcfg.c" />
+    <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\checkcfg.c">
+      <ExcludedFromBuild Condition="'$(Platform)'=='ARM64'">true</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\commit_mode.cpp" />
     <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\debugger_jmc.c" />
     <ClCompile Include="$(VC_CRT_SourcePath.Split(%3B)[0])\vcruntime\denormal_control.cpp" />

--- a/test/driver/CMakeLists.txt
+++ b/test/driver/CMakeLists.txt
@@ -4,6 +4,8 @@ project(crtsys_test LANGUAGES C CXX)
 
 include(../../cmake/CPM.cmake)
 
+option(CRTSYS_TEST_BREAKPOINT "Break into the kernel debugger when the test driver loads" ON)
+
 set(CRTSYS_NTL_MAIN ON)
 CPMAddPackage(NAME crtsys SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..)
 include(${crtsys_SOURCE_DIR}/cmake/CrtSys.cmake)
@@ -51,6 +53,10 @@ if (NOT CRTSYS_TEST_NLOHMANN_JSON)
 endif()
 
 crtsys_add_driver(crtsys_test ${SOURCE_FILES})
+
+if (NOT CRTSYS_TEST_BREAKPOINT)
+    target_compile_definitions(crtsys_test PRIVATE "CRTSYS_TEST_NO_BREAKPOINT")
+endif()
 
 if (CRTSYS_TEST_NLOHMANN_JSON)
     target_compile_definitions(crtsys_test PRIVATE "CRTSYS_TEST_NLOHMANN_JSON")

--- a/test/driver/src/main.cpp
+++ b/test/driver/src/main.cpp
@@ -26,7 +26,9 @@ void test_all();
 
 ntl::status ntl::main(ntl::driver &driver, const std::wstring &registry_path) {
 
+#ifndef CRTSYS_TEST_NO_BREAKPOINT
   KdBreakPoint();
+#endif
 
   std::wcout << "load (registry_path :" << registry_path << ")\n";
 
@@ -96,7 +98,9 @@ DriverEntry (
   PAGED_CODE();
   UNREFERENCED_PARAMETER(RegistryPath);
 
+#ifndef CRTSYS_TEST_NO_BREAKPOINT
   KdBreakPoint();
+#endif
 
   test_all();
 


### PR DESCRIPTION
## Summary
- refresh the CMake workflow to use `windows-2022`, `actions/checkout@v4`, and the latest project-validated Windows SDK line: `10.0.22621.0`
- add reusable PowerShell CI helpers for building, test-signing drivers, and loading/running the x64 driver tests
- build app targets for x86, x64, and ARM64 on GitHub-hosted runners
- build, test-sign, and upload x64 and ARM64 test driver artifacts on GitHub-hosted runners
- add a `CRTSYS_TEST_BREAKPOINT=OFF` CMake path so CI can load the test driver without requiring an attached kernel debugger
- patch the project shims needed to build the driver targets on the current GitHub-hosted VS 2022/MSVC runner while keeping SDK targeting pinned to `10.0.22621.0`
- document the self-hosted driver load-test runner setup in `docs/ci-driver-load-tests.md`

## Notes
- The regular hosted job builds the app for x86, x64, and ARM64, builds the driver for x64 and ARM64, then test-signs and uploads the signed driver artifacts.
- The hosted job also uploads the x64 test app artifact so the self-hosted load-test runner does not need Visual Studio, CMake, or the WDK.
- With `workflow_dispatch` and `run_driver_load_tests=true`, the workflow preflights for an online `crtsys-driver-test` self-hosted Windows x64 runner, downloads the current run artifacts, loads the signed x64 driver, and runs the x64 unit test app.
- That split is intentional: Windows requires TESTSIGNING to be enabled before boot for test-signed x64 kernel-mode drivers, which is not a good fit for ordinary ephemeral hosted runners.
- ARM64 driver build/signing is validated, but ARM64 load testing would require a separate Windows ARM64 self-hosted runner and a matching load-test job.

## Validation
- `python3` YAML parse for `.github/workflows/cmake.yml`
- `python3` XML parse for `src/vcruntime.props`
- `git diff --check`
- PR GitHub Actions run passed: https://github.com/ntoskrnl7/crtsys/actions/runs/27288134610
- Manual GitHub Actions run passed: https://github.com/ntoskrnl7/crtsys/actions/runs/27288143130
- Artifacts uploaded: `crtsys-test-driver-x64`, `crtsys-test-driver-ARM64`, `crtsys-test-app-x64`

PowerShell AST parsing was not run locally because this environment does not have `pwsh`, and `actionlint` is not installed locally. The Windows build/test-sign/artifact path was validated on GitHub Actions. The actual x64 load-test path requires a prepared self-hosted runner; this repository currently has no self-hosted runner registered.