### PR TITLE
[codex] improve README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,374 +1,234 @@
 # crtsys
 
-**C**/C++ Run**t**ime library for **sys**tem file (Windows Kernel Driver)
+**C**/C++ Run**t**ime support for Windows kernel **sys** drivers.
 
 [![CMake](https://github.com/ntoskrnl7/crtsys/actions/workflows/cmake.yml/badge.svg)](https://github.com/ntoskrnl7/crtsys/actions/workflows/cmake.yml)
 ![GitHub](https://img.shields.io/github/license/ntoskrnl7/crtsys)
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/ntoskrnl7/crtsys)
-![Windows 7+](https://img.shields.io/badge/Windows-7+-blue?logo=windows&logoColor=white)
-![Visual Studio 2017+](https://img.shields.io/badge/Visual%20Studio-2017+-682270?logo=visualstudio&logoColor=682270)
-![CMake 3.14+](https://img.shields.io/badge/CMake-3.14+-yellow.svg?logo=cmake&logoColor=white)
-![C++ 14+](https://img.shields.io/badge/C++-14+-white.svg?logo=cplusplus&logoColor=blue)
-![Architecture](https://img.shields.io/badge/CPU-x86%20%2F%20x64%20%2F%20ARM%20%2F%20ARM64-blue.svg?logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIj8+CjxzdmcgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgNTIgNTIiIGlkPSJMYXllcl8xIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8Zz4KICAgICAgICA8cGF0aCBmaWxsPSJ3aGl0ZSIgZD0iTTQ5LDE5LjV2LTJoLTYuOTk4NDEzMXYtNy40OTU3ODg2SDE0LjQwMTYxMTNsLTQuNDAwMDI0NCw0LjUzMDAyOTN2MjcuNDY5OTcwN0gxNy41VjQ5aDJ2LTYuOTk1Nzg4NmgzVjQ5aDJ2LTYuOTk1Nzg4NmgzICAgVjQ5aDJ2LTYuOTk1Nzg4NmgzVjQ5aDJ2LTYuOTk1Nzg4NmgyLjgxMTU4NDVsNC42OTAwMDI0LTUuNjQwMDE0NlYzNC41SDQ5di0yaC02Ljk5ODQxMzF2LTNINDl2LTJoLTYuOTk4NDEzMXYtM0g0OXYtMmgtNi45OTg0MTMxICAgdi0zSDQ5eiBNMzYuMDAxNTg2OSwzMy41MDQyMTE0YzAsMS42NTAwMjQ0LTEuMzQ5OTc1NiwzLTMsM2gtMTRjLTEuNjU5OTczMSwwLTMtMS4zNDk5NzU2LTMtM3YtMTRjMC0xLjY1OTk3MzEsMS4zNDAwMjY5LTMsMy0zaDE0ICAgYzEuNjUwMDI0NCwwLDMsMS4zNDAwMjY5LDMsM1YzMy41MDQyMTE0eiIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSIyIiB3aWR0aD0iNyIgeD0iMyIgeT0iMTcuNSIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSIyIiB3aWR0aD0iNyIgeD0iMyIgeT0iMjIuNSIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSIyIiB3aWR0aD0iNyIgeD0iMyIgeT0iMjcuNSIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSIyIiB3aWR0aD0iNyIgeD0iMyIgeT0iMzIuNSIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSI3IiB3aWR0aD0iMiIgeD0iMzIuNSIgeT0iMyIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSI3IiB3aWR0aD0iMiIgeD0iMjcuNSIgeT0iMyIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSI3IiB3aWR0aD0iMiIgeD0iMjIuNSIgeT0iMyIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSI3IiB3aWR0aD0iMiIgeD0iMTcuNSIgeT0iMyIgLz4KICAgIDwvZz4KPC9zdmc+)
+![GitHub release](https://img.shields.io/github/v/release/ntoskrnl7/crtsys)
+![Windows 7+](https://img.shields.io/badge/Windows-7%2B-blue?logo=windows&logoColor=white)
+![Visual Studio 2017+](https://img.shields.io/badge/Visual%20Studio-2017%2B-682270?logo=visualstudio&logoColor=white)
+![CMake 3.14+](https://img.shields.io/badge/CMake-3.14%2B-064f8c?logo=cmake&logoColor=white)
+![C++14+](https://img.shields.io/badge/C%2B%2B-14%2B-00599c?logo=cplusplus&logoColor=white)
 
-* [한국어 (Korean) 보기](./docs/ko-kr.md)
+[Korean documentation](./docs/ko-kr.md)
 
-[This document has been **machine translated.**]
+`crtsys` is an experimental runtime layer that helps Windows kernel drivers use
+C++ language features, selected Microsoft STL facilities, and small
+kernel-friendly helper abstractions. It is intended for driver projects that
+want a more familiar C++ development model without leaving the WDK/CMake build
+flow.
 
-**crtsys** is open source library that helps you use C++ CRT and STL features in your kernel drivers.
+The project combines three pieces:
 
-- [crtsys](#crtsys)
-  - [Overview](#overview)
-  - [Goal](#goal)
-    - [C++ Standard](#c-standard)
-      - [STL](#stl)
-    - [C Standard](#c-standard-1)
-    - [NTL (NT Template Library)](#ntl-nt-template-library)
-  - [Requirements](#requirements)
-  - [Test Environments](#test-environments)
-  - [Build & Test](#build--test)
-  - [Usage](#usage)
-  - [TODO](#todo)
+- CRT/STL compatibility glue for kernel-mode builds.
+- [`Ldk`](https://github.com/ntoskrnl7/ldk), which provides a subset of
+  Win32/NTDLL-like APIs used by the runtime and STL.
+- NTL, a small C++ helper layer for common driver objects and synchronization.
 
-## Overview
+## Status
 
-This project has the most support for C++ STL features among similar projects.
+This project is not a full user-mode CRT, not a complete Windows compatibility
+layer, and not a replacement for careful driver design. It enables useful C++
+and STL scenarios in kernel mode, but every driver should still be tested under
+the exact Windows, WDK, SDK, Visual Studio, architecture, and verifier settings
+that it will ship with.
 
-<details>
-<summary>more</summary>
+Known constraints:
 
-We investigated the functions that help us to use C++ and STL in the kernel driver, and among them, the best implemented project to use is as follows.
+- Thread-local storage and thread-safe local static initialization are not
+  supported yet.
+- Kernel stacks are small; use `ntl::expand_stack` for paths that need more
+  stack, especially exception-heavy or STL-heavy paths.
+- SDK and WDK version mismatches can cause build failures. Prefer matching SDK
+  and WDK versions.
+- New Windows 11 24H2 WDK releases no longer support x86 kernel-mode driver
+  development. Use WDK 23H2 or older when x86 driver targets are required.
 
-(22-04-26)
+## Features
 
-* [UCXXRT](https://github.com/MiroKaku/ucxxrt)
-  * Pros
-    * The concept of using the [Microsoft STL](https://github.com/microsoft/STL) directly looks good.
-  * Cons
-    * Until now, only functions related to data types or data structures such as std::string and std::vector classes, which have little relevance to Win32 API, are supported.
-    * Since vcxproj is dependent on the development environment, if the VS version changes, you have to manually modify it.
-    * Hanging occurs on x86. [this code](https://en.cppreference.com/w/cpp/language/throw#Example)
-    * It seems that they copied Microsoft's source code as it is and put their own license comments at the top and included it in the project, and it does not seem to be free from licensing problems.
-      * Changing the license and redistributing the Microsoft CRT and STL source code are not permitted.
+The README keeps this section short. The detailed, test-linked checklist lives
+in the documentation directory:
 
-* [KTL](https://github.com/DymOK93/KTL)
-  * Pros
-    * CMake
-      * Easy to create and automate project files suitable for development environment.
-    * Independent implementation of all code including CRT
-      * It is free from license, and the exception handling code part is lightweight, which can save the stack.
-    * Provides a template library specialized for the kernel
-      * Because it provides a template library for mechanisms that exist only in the kernel, there are many functions that can be used more favorably than STL when making an actual driver.
-    * high quality code.
-  * Cons
-    * MIt seems that it was written with consideration to using Microsoft STL, but I feel it is difficult to actually change to use Microsoft STL (there were more typos and code using only ktl than I thought)
-    * Russian comments, but the file is not UTF8+BOM encoded, so the build fails in a non-Russian environment.
-    * x86 not supported.
+- [Detailed feature coverage](./docs/feature-coverage.md)
+- [NTL API reference](./docs/ntl-api.md)
 
-While I was working to make up for the shortcomings of each library, I developed a new library for the following reasons.
+High-level coverage:
 
-1. UCXXRT copied the Microsoft CRT source code as is and included it in the project.
-2. KTL does not support x86.
-
-The advantages of crtsys are as follows.
-
-1. Microsoft CRT source code is used to support the Microsoft CRT and STL as closely as possible, but it builds and processes the source directly in the directory where Microsoft Visual Studio or Build Tools are installed, so users who use Visual Studio legally can be licensed. . You can use it without any problems.
-2. It supports a wide range of STL features by leveraging [Ldk](https://github.com/ntoskrnl7/Ldk) that implement the Win32 API.
-3. You can organize your projects with CMake, and [CPM](https://github.com/cpm-cmake/CPM.cmake) makes it really easy to use the library.
-
-</details>
-
-## Goal
-
-This project aims to provide a development experience similar to using C++ and STL in your applications when writing kernel drivers.
-
-Features currently supported or supported in the future are listed below.
-
-* Checked items are items that have been implemented.
-* For the item where the test code is written, a link to the test code is added.
-
-### C++ Standard
-
-It was written based on the [C++ reference](https://en.cppreference.com)
-
-* [Initialization](https://en.cppreference.com/w/cpp/language/initialization)
-  * [x] [Non-local variables](https://en.cppreference.com/w/cpp/language/initialization#Non-local_variables)
-    * [x] [Static initialization](https://en.cppreference.com/w/cpp/language/initialization#Static_initialization)
-      * [x] [Constant initialization](https://en.cppreference.com/w/cpp/language/constant_initialization) [(tested)](./test/driver/src/cpp/lang/initialization.cpp#L13)
-      * [x] [Zero initialization](https://en.cppreference.com/w/cpp/language/zero_initialization) [(tested)](./test/driver/src/cpp/lang/initialization.cpp#L41)
-    * [x] [Dynamic initialization](https://en.cppreference.com/w/cpp/language/initialization#Dynamic_initialization) [(tested)](./test/driver/src/cpp/lang/initialization.cpp#L65)
-  * [ ] [Static local variables](https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables)
-    * [ ] thread_local
-    * [ ] static
-* [Exceptions](https://en.cppreference.com/w/cpp/language/exceptions)
-  * [x] [throw](https://en.cppreference.com/w/cpp/language/throw) [(tested)](./test/driver/src/cpp/lang/exceptions.cpp#L42)
-  * [x] [try-block](https://en.cppreference.com/w/cpp/language/try_catch) [(tested)](./test/driver/src/cpp/lang/exceptions.cpp#L60)
-  * [x] [Function-try-block](https://en.cppreference.com/w/cpp/language/function-try-block) [(tested)](./test/driver/src/cpp/lang/exceptions.cpp#L98)
-
-#### STL
-
-* [x] [std::chrono](https://en.cppreference.com/w/cpp/chrono) [(tested)](./test/driver/src/cpp/stl/chrono.cpp#L15)
-* [x] [std::thread](https://en.cppreference.com/w/cpp/thread) [(tested)](./test/driver/src/cpp/stl/thread.cpp#L35)
-* [x] [std::condition_variable](https://en.cppreference.com/w/cpp/thread/condition_variable) [(tested)](./test/driver/src/cpp/stl/thread.cpp#L35)
-* [x] [std::mutex](https://en.cppreference.com/w/cpp/thread/mutex) [(tested)](./test/driver/src/cpp/stl/thread.cpp#L81)
-* [x] [std::shared_mutex](https://en.cppreference.com/w/cpp/thread/shared_mutex) [(tested)](./test/driver/src/cpp/stl/thread.cpp#L129)
-* [x] [std::future](https://en.cppreference.com/w/cpp/thread/future) [(tested)](./test/driver/src/cpp/stl/thread.cpp#L157)
-* [x] [std::promise](https://en.cppreference.com/w/cpp/thread/promise) [(tested)](./test/driver/src/cpp/stl/thread.cpp#L203)
-* [x] [std::packaged_task](https://en.cppreference.com/w/cpp/thread/packaged_task) [(tested)](./test/driver/src/cpp/stl/thread.cpp#L267)
-* [x] [std::cin](https://en.cppreference.com/w/cpp/io/cin)
-* [x] [std::clog](https://en.cppreference.com/w/cpp/io/clog)
-* [x] [std::cerr](https://en.cppreference.com/w/cpp/io/cerr)
-* [x] [std::cout](https://en.cppreference.com/w/cpp/io/cout) (tested)
-* [x] [std::wcin](https://en.cppreference.com/w/cpp/io/cin)
-* [x] [std::wclog](https://en.cppreference.com/w/cpp/io/clog)
-* [x] [std::wcerr](https://en.cppreference.com/w/cpp/io/cerr)
-* [x] [std::wcout](https://en.cppreference.com/w/cpp/io/cout) (tested)
-
-### C Standard
-
-* [x] math functions
-  * I did not have enough time to implement it myself, so I referred to the contents of the project below. thank you! :-)
-  * [RetrievAL](https://github.com/SpoilerScriptsGroup/RetrievAL)
-  * [musl](https://github.com/bminor/musl)
-
-### NTL (NT Template Library)
-
-Provides features to support a better development environment in the kernel.
-
-* ntl::expand_stack [(tested)](./test/driver/src/ntl.cpp#L5)
-  * Function to extend the stack size
-  * By default, the kernel stack is allocated a much smaller size than the user thread stack, so it is recommended to use the STL function or especially when performing throw.
-* ntl::status
-  * Class for NTSTATUS
-* ntl::driver
-  * Class for DRIVER_OBJECT
-  * Features
-    * [x] DriverUnload [(tested)](./test/driver/src/main.cpp#L73)
-    * [x] Create device [(tested)](./test/driver/src/main.cpp#L44)
-* ntl::device
-  * Class for DEVICE_OBJECT
-  * Features
-    * [x] Device Extension [(tested)](./test/driver/src/main.cpp#L33)
-    * [ ] IRP_MJ_CREATE
-    * [ ] IRP_MJ_CLOSE
-    * [x] IRP_MJ_DEVICE_CONTROL [(tested)](./test/app/src/main.cpp#L77) [(tested)](./test/driver/src/main.cpp#L55)
-* ntl::driver_main [(tested)](./test/driver/src/main.cpp#L25)
-  * Driver entry point for C++.
-  * Called by expanding the stack to its maximum size with the ntl::expand_stack function.
-* ntl::rpc
-  * Provides an easy communication method between User Mode Application and Kernel Driver.
-    * ntl::rpc::server [(tested)](./test/driver/src/main.cpp#L19) [(tested)](./test/common/rpc.hpp)
-    * ntl::rpc::client [(tested)](./test/app/src/main.cpp#L4) [(tested)](./test/common/rpc.hpp)
-      * I did not have enough time to implement the data serialization part myself, so I referred to the contents of the project below. thank you! :-)
-        * [Eyal Z/zpp serializer](https://github.com/eyalz800/serializer)
-* ntl::irql
-  * Class for KIRQL
-  * Classes
-    * ntl::irql [(tested)](./test/driver/src/ntl.cpp#L46)
-  * Functions
-    * ntl::raise_irql [(tested)](./test/driver/src/ntl.cpp#L49)
-    * raise_irql_to_dpc_level [(tested)](./test/driver/src/ntl.cpp#L62)
-    * raise_irql_to_synch_level [(tested)](./test/driver/src/ntl.cpp#L71)
-* ntl::spin_lock
-  * Class for KSPIN_LOCK
-  * Classes
-    * ntl::spin_lock [(tested)](./test/driver/src/ntl.cpp#L80)
-    * ntl::unique_lock [(tested)](./test/driver/src/ntl.cpp#L99)
-* ntl::resource
-  * Class for ERESOURCE
-  * Classes
-    * ntl::resource [(tested)](./test/driver/src/ntl.cpp#L117)
-    * ntl::unique_lock [(tested)](./test/driver/src/ntl.cpp#L156)
-    * ntl::shared_lock [(tested)](./test/driver/src/ntl.cpp#L179)
+- C++ runtime support
+  - non-local static initialization
+  - dynamic initialization
+  - exceptions
+- Microsoft STL support
+  - time utilities
+  - threading primitives
+  - synchronization primitives
+  - async primitives
+  - stream objects
+- C runtime support
+  - CRT glue needed by the supported STL paths
+  - math helpers
+  - floating-point classification helpers
+- NTL support
+  - C++ driver entry point wrapper
+  - driver and device helpers
+  - RPC helpers
+  - IRQL and synchronization helpers
 
 ## Requirements
 
-* Windows 7 or later
-* [Visual Studio / Build Tools 2017 or later](https://visualstudio.microsoft.com/ko/downloads/)
-* [CMake 3.16 or later](https://cmake.org/download/)
-* [Git](https://git-scm.com/downloads)
+- Windows 7 or later
+- Visual Studio or Build Tools 2017 or later
+- Windows SDK and WDK compatible with the selected Visual Studio toolset
+- CMake 3.14 or later
+- Git
 
-## Test Environments
+Tested toolchains include Visual Studio 2017, 2019, and 2022 with WDK/SDK
+versions such as `10.0.17763.0`, `10.0.18362.0`, `10.0.22000.0`, and
+`10.0.22621.0`.
 
-* Windows 10 x64
-  * It can be built with **x86, x64, ARM, ARM64**, but the actual test has only been validated against x86 and x64 modules.
+Visual Studio 2017 has missing CRT source/header pieces for some paths, so
+`crtsys` uses selected UCXXRT compatibility code for that toolset.
 
-* CMake 3.21.4
-* Git 2.23.0
-* Visual Studio 2017
-  * Visual Studio 2017's CRT source code was missing some headers and could not be built, so it is supported using some of UCXXRT code.
-  * In the future, we plan to support by manually writing the missing header.
-* Visual Studio 2019
-* Visual Studio 2022
-* VC Tools
-  * 14.16.27023
-  * 14.24.28314
-  * 14.26.28801
-  * 14.29.30133
-  * 14.31.31103
-  * 14.33.31629
-* Windows Kits (SDK, WDK)
-  * 10.0.17763.0
-  * 10.0.18362.0
-  * 10.0.22000.0
-  * 10.0.22621.0
+## Quick Start
 
-If the SDK and WDK versions are different, builds are more likely to fail. **If possible, it is recommended to build in the same environment as the SDK and WDK versions.**
+Create a driver project, place CPM at `cmake/CPM.cmake`, and add `crtsys`:
 
-## Build & Test
+```cmake
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 
-CI driver load tests are documented in
-[CI driver load tests](./docs/ci-driver-load-tests.md).
+project(my_driver LANGUAGES C CXX)
 
-1. Please build the library and test code by executing the command below.
+include(cmake/CPM.cmake)
 
-    ```Batch
-    git clone https://github.com/ntoskrnl7/crtsys
-    cd crtsys\test\build.bat
-    ```
+set(CRTSYS_NTL_MAIN ON)
+CPMAddPackage("gh:ntoskrnl7/crtsys@0.1.10")
+include(${crtsys_SOURCE_DIR}/cmake/CrtSys.cmake)
 
-    Alternatively, if you execute the command below, both Debug and Release configurations are built for all supported architectures.
+crtsys_add_driver(my_driver src/main.cpp)
+```
 
-    ```Batch
-    git clone https://github.com/ntoskrnl7/crtsys
-    cd crtsys
-    build_all.bat test\app
-    build_all.bat test\driver
-    ```
+`CRTSYS_NTL_MAIN` enables the C++ entry point wrapper. With it enabled, define
+`ntl::main` instead of writing `DriverEntry` directly:
 
-2. Install and load build\Debug\crtsys_test.sys.
+```cpp
+#include <iostream>
+#include <string>
+#include <ntl/driver>
 
-   * driver
-    x64 : test\driver\build_x64\Debug\crtsys_test.sys
-    x86 : test\driver\build_x86\Debug\crtsys_test.sys
-    ARM : test\driver\build_ARM\Debug\crtsys_test.sys
-    ARM64 : test\driver\build_ARM64\Debug\crtsys_test.sys
-   * app
-    x64 : test\driver\build_x64\Debug\crtsys_test_app.exe
-    x86 : test\driver\build_x86\Debug\crtsys_test_app.exe
-    ARM : test\driver\build_ARM\Debug\crtsys_test_app.exe
-    ARM64 : test\driver\build_ARM64\Debug\crtsys_test_app.exe
+ntl::status ntl::main(ntl::driver& driver,
+                      const std::wstring& registry_path) {
+  std::wcout << L"load: " << registry_path << L"\n";
 
-   ```batch
-   sc create CrtSysTest binpath= "crtsys_test.sys full path" displayname= "crtsys test" start= demand type= kernel
-   sc start CrtSysTest
+  driver.on_unload([registry_path]() {
+    std::wcout << L"unload: " << registry_path << L"\n";
+  });
 
-   crtsys_test.app.exe
+  return ntl::status::ok();
+}
+```
 
-   sc stop CrtSysTest
-   sc delete CrtSysTest
-   ```
+If `CRTSYS_NTL_MAIN` is disabled, keep the normal WDK `DriverEntry` entry
+point and initialize your driver manually.
 
-3. If it loads normally and passes/unloads Google Test, the test is successful, and the test contents can be checked through DebugView or WinDbg.
+Build the project with a Visual Studio generator:
 
-## Usage
+```bat
+cmake -S . -B build_x64 -A x64
+cmake --build build_x64 --config Debug
+```
 
-1. Please move after creating the project directory.
+## Building This Repository
 
-   ```batch
-   mkdir test-project
-   cd test-project
-   ```
+Clone the repository and build the test app and driver for the host
+architecture:
 
-2. Download CPM to your project directory.
+```bat
+git clone https://github.com/ntoskrnl7/crtsys
+cd crtsys
+test\build.bat
+```
 
-    ```batch
-    mkdir cmake
-    wget -O cmake/CPM.cmake https://github.com/cpm-cmake/CPM.cmake/releases/latest/download/get_cpm.cmake
-    ```
+Build a specific target manually:
 
-    or
+```bat
+build.bat test\app x64 Debug
+build.bat test\driver x64 Debug
+build.bat test\app x64 Release
+build.bat test\driver x64 Release
+```
 
-    ```batch
-    mkdir cmake
-    curl -o cmake/CPM.cmake -LJO https://github.com/cpm-cmake/CPM.cmake/releases/latest/download/get_cpm.cmake
-    ```
+Build all supported architecture/configuration combinations:
 
-3. Please write the following files in the project directory.
+```bat
+build_all.bat test\app
+build_all.bat test\driver
+```
 
-   * Directory structure
+Typical Debug outputs:
 
-      ```tree
-      📦test-project
-      ┣ 📂src
-      ┃ ┗ 📜main.cpp
-      ┗ 📜CMakeLists.txt
-      ```
+```text
+test\driver\build_x64\Debug\crtsys_test.sys
+test\app\build_x64\Debug\crtsys_test_app.exe
+```
 
-   * CMakeLists.txt
+## Running Tests
 
-        ```CMake
-        cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+`crtsys_test.sys` is a kernel driver. Build validation can happen in CI, but
+loading and executing the test driver must happen in a Windows driver test
+environment.
 
-        project(crtsys_test LANGUAGES C CXX)
+The CI build workflow and optional self-hosted driver load test path are
+documented in [CI driver load tests](./docs/ci-driver-load-tests.md).
 
-        include(cmake/CPM.cmake)
+```bat
+sc create CrtSysTest binpath= "C:\path\to\crtsys_test.sys" displayname= "crtsys test" start= demand type= kernel
+sc start CrtSysTest
 
-        set(CRTSYS_NTL_MAIN ON) # use ntl::main
-        CPMAddPackage("gh:ntoskrnl7/crtsys@0.1.10")
-        include(${crtsys_SOURCE_DIR}/cmake/CrtSys.cmake)
+C:\path\to\crtsys_test_app.exe
 
-        # add driver
-        crtsys_add_driver(crtsys_test src/main.cpp)
-        ```
+sc stop CrtSysTest
+sc delete CrtSysTest
+```
 
-   * src/main.cpp
+The test driver uses Google Test internally. Inspect output with DebugView,
+WinDbg, or your normal kernel debugging setup.
 
-        * If you enable CRTSYS_NTL_MAIN as shown below, define ntl::main as the entry point. **(recommend)**
+## Repository Layout
 
-          * CMakeLists.txt
+```text
+cmake/             CMake helpers, including CrtSys.cmake
+include/ntl/       NTL C++ helper headers
+include/.internal/ Internal version and toolchain compatibility headers
+src/               crtsys runtime and CRT/STL compatibility code
+test/app/          User-mode test companion application
+test/driver/       Kernel-mode test driver
+docs/              Additional documentation
+```
 
-              ```CMake
-              set(CRTSYS_NTL_MAIN ON)
-              ```
+## Background
 
-        * If you disable CRTSYS_NTL_MAIN as shown below, define DriverEntry as the entry point, which is different from the previous one.
+`crtsys` was created after experimenting with other kernel C++ runtime
+projects, especially UCXXRT and KTL. The design goal is to keep the CMake/WDK
+workflow practical while supporting a broad enough subset of Microsoft CRT/STL
+behavior for real driver experiments.
 
-          * CMakeLists.txt
+The project avoids treating the Microsoft CRT/STL source as a vendored library.
+Instead, it relies on the locally installed Visual Studio/Build Tools layout
+and layers kernel-mode compatibility code around it. For older toolsets where
+the Microsoft-provided source/header layout is incomplete, small compatibility
+pieces are used.
 
-              ```CMake
-              set(CRTSYS_NTL_MAIN OFF)
-              ```
+Several standalone implementations are also referenced where they are a better
+fit for kernel-mode support:
 
-        Below is example code from a project with ntl::main set as entry point.
+- [RetrievAL](https://github.com/SpoilerScriptsGroup/RetrievAL)
+- [musl](https://github.com/bminor/musl)
+- [zpp serializer](https://github.com/eyalz800/serializer)
 
-        ```C
-        #include <iostream>
-        #include <ntl/driver>
+## Roadmap
 
-        ntl::status ntl::main(ntl::driver &driver, const std::wstring &registry_path) {
-
-          std::wcout << "load (registry_path :" << registry_path << ")\n";
-
-          // TODO
-
-          driver.on_unload([registry_path]() {
-            std::wcout << "unload (registry_path :" << registry_path << ")\n";
-          });
-
-          return status::ok();
-        }
-        ```
-
-4. Perform a build.
-
-   ```batch
-   cmake -S . -B build
-   cmake --build build
-   ```
-
-5. Please check if the driver starts up and shuts down normally.
-
-   ```batch
-   sc create CrtSysTest binpath= "crtsys_test.sys full path" displayname= "crtsys test" start= demand type= kernel
-   sc start CrtSysTest
-   sc stop CrtSysTest
-   sc delete CrtSysTest
-   ```
-
-## TODO
-
-* CMake install handling.
-* Implementing C++ STL features not yet implemented.
-* Build CRT source code in Visual Studio 2017.
-* Running unit tests in GitHub Action.
+- Add CMake install/package handling.
+- Expand unsupported C++ and STL feature coverage.
+- Reduce Visual Studio 2017 compatibility gaps.
+- Add CI coverage for actual driver load/run tests where the environment
+  supports it.

--- a/docs/feature-coverage.md
+++ b/docs/feature-coverage.md
@@ -1,0 +1,126 @@
+# Feature Coverage
+
+[Back to README](../README.md)
+
+This page keeps the detailed support checklist that used to live in the main
+README. Checked items are implemented and have test coverage when a `tested`
+link is attached.
+
+## C++ Standard
+
+The tests are based on examples and behavior described by
+[cppreference](https://en.cppreference.com).
+
+### Initialization
+
+- [x] [Non-local variables](https://en.cppreference.com/w/cpp/language/initialization#Non-local_variables)
+  - [x] [Static initialization](https://en.cppreference.com/w/cpp/language/initialization#Static_initialization)
+    - [x] [Constant initialization](https://en.cppreference.com/w/cpp/language/constant_initialization)
+      [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L13)
+    - [x] [Zero initialization](https://en.cppreference.com/w/cpp/language/zero_initialization)
+      [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L41)
+  - [x] [Dynamic initialization](https://en.cppreference.com/w/cpp/language/initialization#Dynamic_initialization)
+    [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L65)
+- [ ] [Static local variables](https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables)
+  - [ ] `thread_local`
+  - [ ] function-local `static`
+
+### Exceptions
+
+- [x] [throw](https://en.cppreference.com/w/cpp/language/throw)
+  [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L42)
+- [x] [try block](https://en.cppreference.com/w/cpp/language/try_catch)
+  [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L60)
+- [x] [Function try block](https://en.cppreference.com/w/cpp/language/function-try-block)
+  [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L98)
+
+## Microsoft STL
+
+- [x] [std::chrono](https://en.cppreference.com/w/cpp/chrono)
+  [(tested)](../test/driver/src/cpp/stl/chrono.cpp#L15)
+- [x] [std::thread](https://en.cppreference.com/w/cpp/thread)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L35)
+- [x] [std::condition_variable](https://en.cppreference.com/w/cpp/thread/condition_variable)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L35)
+- [x] [std::mutex](https://en.cppreference.com/w/cpp/thread/mutex)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L81)
+- [x] [std::shared_mutex](https://en.cppreference.com/w/cpp/thread/shared_mutex)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L129)
+- [x] [std::future](https://en.cppreference.com/w/cpp/thread/future)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L157)
+- [x] [std::promise](https://en.cppreference.com/w/cpp/thread/promise)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L203)
+- [x] [std::packaged_task](https://en.cppreference.com/w/cpp/thread/packaged_task)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L267)
+- [x] [std::cin](https://en.cppreference.com/w/cpp/io/cin)
+- [x] [std::cout](https://en.cppreference.com/w/cpp/io/cout)
+- [x] [std::cerr](https://en.cppreference.com/w/cpp/io/cerr)
+- [x] [std::clog](https://en.cppreference.com/w/cpp/io/clog)
+- [x] [std::wcin](https://en.cppreference.com/w/cpp/io/cin)
+- [x] [std::wcout](https://en.cppreference.com/w/cpp/io/cout)
+- [x] [std::wcerr](https://en.cppreference.com/w/cpp/io/cerr)
+- [x] [std::wclog](https://en.cppreference.com/w/cpp/io/clog)
+- [x] `nlohmann::json` integration
+  [(tested)](../test/driver/src/libs/nlohmann_json.cpp)
+
+## C Standard
+
+- [x] Math functions
+  - adapted where needed from small portable implementations
+  - references:
+    [RetrievAL](https://github.com/SpoilerScriptsGroup/RetrievAL),
+    [musl](https://github.com/bminor/musl)
+- [x] Floating-point classification helpers
+  [(source)](../src/custom/crt/math/fpclassify.c)
+
+## NTL: NT Template Library
+
+NTL provides C++ helpers for driver code. See the
+[NTL API reference](./ntl-api.md) for API-level details.
+
+- [x] `ntl::expand_stack`
+  [(tested)](../test/driver/src/ntl.cpp#L5)
+- [x] `ntl::status`
+- [x] `ntl::driver`
+  - [x] unload callback
+    [(tested)](../test/driver/src/main.cpp#L73)
+  - [x] device creation
+    [(tested)](../test/driver/src/main.cpp#L44)
+- [x] `ntl::device`
+  - [x] device extension
+    [(tested)](../test/driver/src/main.cpp#L33)
+  - [ ] `IRP_MJ_CREATE`
+  - [ ] `IRP_MJ_CLOSE`
+  - [x] `IRP_MJ_DEVICE_CONTROL`
+    [(app test)](../test/app/src/main.cpp#L77)
+    [(driver test)](../test/driver/src/main.cpp#L55)
+- [x] `ntl::main`
+  [(tested)](../test/driver/src/main.cpp#L25)
+- [x] `ntl::rpc`
+  - [x] `ntl::rpc::server`
+    [(tested)](../test/driver/src/main.cpp#L19)
+    [(schema)](../test/common/rpc.hpp)
+  - [x] `ntl::rpc::client`
+    [(tested)](../test/app/src/main.cpp#L4)
+    [(schema)](../test/common/rpc.hpp)
+- [x] `ntl::irql`
+  - [x] `ntl::irql`
+    [(tested)](../test/driver/src/ntl.cpp#L46)
+  - [x] `ntl::raise_irql`
+    [(tested)](../test/driver/src/ntl.cpp#L49)
+  - [x] `ntl::raise_irql_to_dpc_level`
+    [(tested)](../test/driver/src/ntl.cpp#L62)
+  - [x] `ntl::raise_irql_to_synch_level`
+    [(tested)](../test/driver/src/ntl.cpp#L71)
+- [x] `ntl::spin_lock`
+  - [x] `ntl::spin_lock`
+    [(tested)](../test/driver/src/ntl.cpp#L80)
+  - [x] `ntl::unique_lock<ntl::spin_lock>`
+    [(tested)](../test/driver/src/ntl.cpp#L99)
+- [x] `ntl::resource`
+  - [x] `ntl::resource`
+    [(tested)](../test/driver/src/ntl.cpp#L117)
+  - [x] `ntl::unique_lock<ntl::resource>`
+    [(tested)](../test/driver/src/ntl.cpp#L156)
+  - [x] `ntl::shared_lock<ntl::resource>`
+    [(tested)](../test/driver/src/ntl.cpp#L179)

--- a/docs/ko-kr-feature-coverage.md
+++ b/docs/ko-kr-feature-coverage.md
@@ -1,0 +1,126 @@
+# 기능 지원 현황
+
+[한국어 문서로 돌아가기](./ko-kr.md)
+
+이 문서는 기존 README의 `Goal` 섹션이 갖고 있던 상세 지원 현황을 보존하기
+위한 문서입니다. 체크된 항목은 구현된 항목이며, `tested` 링크가 있는 항목은
+테스트 코드 위치를 함께 표시합니다.
+
+## C++ Standard
+
+테스트는 [cppreference](https://en.cppreference.com)의 예제와 동작 설명을
+기준으로 작성되었습니다.
+
+### Initialization
+
+- [x] [Non-local variables](https://en.cppreference.com/w/cpp/language/initialization#Non-local_variables)
+  - [x] [Static initialization](https://en.cppreference.com/w/cpp/language/initialization#Static_initialization)
+    - [x] [Constant initialization](https://en.cppreference.com/w/cpp/language/constant_initialization)
+      [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L13)
+    - [x] [Zero initialization](https://en.cppreference.com/w/cpp/language/zero_initialization)
+      [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L41)
+  - [x] [Dynamic initialization](https://en.cppreference.com/w/cpp/language/initialization#Dynamic_initialization)
+    [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L65)
+- [ ] [Static local variables](https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables)
+  - [ ] `thread_local`
+  - [ ] function-local `static`
+
+### Exceptions
+
+- [x] [throw](https://en.cppreference.com/w/cpp/language/throw)
+  [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L42)
+- [x] [try block](https://en.cppreference.com/w/cpp/language/try_catch)
+  [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L60)
+- [x] [Function try block](https://en.cppreference.com/w/cpp/language/function-try-block)
+  [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L98)
+
+## Microsoft STL
+
+- [x] [std::chrono](https://en.cppreference.com/w/cpp/chrono)
+  [(tested)](../test/driver/src/cpp/stl/chrono.cpp#L15)
+- [x] [std::thread](https://en.cppreference.com/w/cpp/thread)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L35)
+- [x] [std::condition_variable](https://en.cppreference.com/w/cpp/thread/condition_variable)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L35)
+- [x] [std::mutex](https://en.cppreference.com/w/cpp/thread/mutex)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L81)
+- [x] [std::shared_mutex](https://en.cppreference.com/w/cpp/thread/shared_mutex)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L129)
+- [x] [std::future](https://en.cppreference.com/w/cpp/thread/future)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L157)
+- [x] [std::promise](https://en.cppreference.com/w/cpp/thread/promise)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L203)
+- [x] [std::packaged_task](https://en.cppreference.com/w/cpp/thread/packaged_task)
+  [(tested)](../test/driver/src/cpp/stl/thread.cpp#L267)
+- [x] [std::cin](https://en.cppreference.com/w/cpp/io/cin)
+- [x] [std::cout](https://en.cppreference.com/w/cpp/io/cout)
+- [x] [std::cerr](https://en.cppreference.com/w/cpp/io/cerr)
+- [x] [std::clog](https://en.cppreference.com/w/cpp/io/clog)
+- [x] [std::wcin](https://en.cppreference.com/w/cpp/io/cin)
+- [x] [std::wcout](https://en.cppreference.com/w/cpp/io/cout)
+- [x] [std::wcerr](https://en.cppreference.com/w/cpp/io/cerr)
+- [x] [std::wclog](https://en.cppreference.com/w/cpp/io/clog)
+- [x] `nlohmann::json` 연동
+  [(tested)](../test/driver/src/libs/nlohmann_json.cpp)
+
+## C Standard
+
+- [x] Math functions
+  - 필요한 경우 작은 portable 구현을 참고해 보강했습니다.
+  - 참고:
+    [RetrievAL](https://github.com/SpoilerScriptsGroup/RetrievAL),
+    [musl](https://github.com/bminor/musl)
+- [x] Floating-point classification helpers
+  [(source)](../src/custom/crt/math/fpclassify.c)
+
+## NTL: NT Template Library
+
+NTL은 드라이버 코드를 위한 C++ helper를 제공합니다. API 수준 설명은
+[NTL API 문서](./ko-kr-ntl-api.md)를 참고하세요.
+
+- [x] `ntl::expand_stack`
+  [(tested)](../test/driver/src/ntl.cpp#L5)
+- [x] `ntl::status`
+- [x] `ntl::driver`
+  - [x] unload callback
+    [(tested)](../test/driver/src/main.cpp#L73)
+  - [x] device creation
+    [(tested)](../test/driver/src/main.cpp#L44)
+- [x] `ntl::device`
+  - [x] device extension
+    [(tested)](../test/driver/src/main.cpp#L33)
+  - [ ] `IRP_MJ_CREATE`
+  - [ ] `IRP_MJ_CLOSE`
+  - [x] `IRP_MJ_DEVICE_CONTROL`
+    [(app test)](../test/app/src/main.cpp#L77)
+    [(driver test)](../test/driver/src/main.cpp#L55)
+- [x] `ntl::main`
+  [(tested)](../test/driver/src/main.cpp#L25)
+- [x] `ntl::rpc`
+  - [x] `ntl::rpc::server`
+    [(tested)](../test/driver/src/main.cpp#L19)
+    [(schema)](../test/common/rpc.hpp)
+  - [x] `ntl::rpc::client`
+    [(tested)](../test/app/src/main.cpp#L4)
+    [(schema)](../test/common/rpc.hpp)
+- [x] `ntl::irql`
+  - [x] `ntl::irql`
+    [(tested)](../test/driver/src/ntl.cpp#L46)
+  - [x] `ntl::raise_irql`
+    [(tested)](../test/driver/src/ntl.cpp#L49)
+  - [x] `ntl::raise_irql_to_dpc_level`
+    [(tested)](../test/driver/src/ntl.cpp#L62)
+  - [x] `ntl::raise_irql_to_synch_level`
+    [(tested)](../test/driver/src/ntl.cpp#L71)
+- [x] `ntl::spin_lock`
+  - [x] `ntl::spin_lock`
+    [(tested)](../test/driver/src/ntl.cpp#L80)
+  - [x] `ntl::unique_lock<ntl::spin_lock>`
+    [(tested)](../test/driver/src/ntl.cpp#L99)
+- [x] `ntl::resource`
+  - [x] `ntl::resource`
+    [(tested)](../test/driver/src/ntl.cpp#L117)
+  - [x] `ntl::unique_lock<ntl::resource>`
+    [(tested)](../test/driver/src/ntl.cpp#L156)
+  - [x] `ntl::shared_lock<ntl::resource>`
+    [(tested)](../test/driver/src/ntl.cpp#L179)

--- a/docs/ko-kr-ntl-api.md
+++ b/docs/ko-kr-ntl-api.md
@@ -1,0 +1,219 @@
+# NTL API 문서
+
+[한국어 문서로 돌아가기](./ko-kr.md)
+
+NTL은 `crtsys`가 함께 제공하는 작은 C++ helper 레이어입니다. WDK 객체를
+숨기기보다는, 드라이버 코드에서 RAII ownership, callback 등록, user-mode와
+kernel-mode 사이의 간단한 RPC를 쓰기 쉽게 만드는 것을 목표로 합니다.
+
+헤더는 [`include/ntl`](../include/ntl)에 있습니다.
+
+## 진입점
+
+`CRTSYS_NTL_MAIN`을 켜면 다음 함수를 구현합니다.
+
+```cpp
+ntl::status ntl::main(ntl::driver& driver,
+                      const std::wstring& registry_path);
+```
+
+`crtsys`는 WDK driver entry point를 이 함수로 연결합니다. wrapper는
+`ntl::main` 호출 전에 stack expansion helper도 사용합니다.
+
+## `ntl::status`
+
+헤더: [`include/ntl/status`](../include/ntl/status)
+
+`NTSTATUS`를 감싸는 작은 wrapper입니다.
+
+- `status(NTSTATUS status)`
+- `bool is_ok() const`
+- `bool is_info() const`
+- `bool is_warn() const`
+- `bool is_err() const`
+- `operator NTSTATUS() const`
+- `static status ok()`
+
+## Exceptions
+
+헤더: [`include/ntl/except`](../include/ntl/except)
+
+- `ntl::exception`
+  - `ntl::status`를 보관합니다.
+  - 설명 메시지를 함께 가집니다.
+- `ntl::seh::try_except(fn, args...)`
+  - callable을 SEH 안에서 실행합니다.
+  - `{success, exception_code}`를 반환합니다.
+
+## Stack Expansion
+
+헤더: [`include/ntl/expand_stack`](../include/ntl/expand_stack)
+
+기본 커널 스택보다 더 많은 스택이 필요한 경로에서 `ntl::expand_stack`을
+사용합니다.
+
+```cpp
+auto opts = ntl::expand_stack_options().wait(true);
+auto result = ntl::expand_stack(std::move(opts), [] {
+  return do_expensive_work();
+});
+```
+
+API:
+
+- `ntl::expand_stack_size_max`
+- `ntl::expand_stack_options`
+  - `stack_size(size_t)`
+  - `wait(bool)`
+  - `ignore_failure(bool)`
+- `ntl::expand_stack(options, fn, args...)`
+
+## Driver Object
+
+헤더: [`include/ntl/driver`](../include/ntl/driver)
+
+`ntl::driver`는 `DRIVER_OBJECT`를 감쌉니다.
+
+- `create_device<Extension>(device_options&)`
+  - `ntl::device<Extension>`을 생성합니다.
+  - device extension 영역에 extension 객체를 생성합니다.
+- `on_unload(callback)`
+  - C++ unload callback을 등록합니다.
+- `name() const`
+  - driver name을 `std::wstring`으로 반환합니다.
+
+## Device Object
+
+헤더: [`include/ntl/device`](../include/ntl/device)
+
+`ntl::device_options`는 device 생성 옵션을 구성합니다.
+
+- `name(std::wstring)`
+- `type(DEVICE_TYPE)`
+- `exclusive(bool = true)`
+- `name() const`
+- `type() const`
+- `is_exclusive() const`
+
+`ntl::device<Extension>`은 `PDEVICE_OBJECT`를 소유합니다.
+
+- `extension()`
+  - typed extension 객체를 반환합니다.
+- `on_device_control(callback)`
+  - `IRP_MJ_DEVICE_CONTROL` handler를 등록합니다.
+- `name() const`
+- `type() const`
+- `detach()`
+  - raw device object ownership을 해제합니다.
+
+Device control helper type:
+
+- `ntl::device_control::code`
+- `ntl::device_control::in_buffer`
+- `ntl::device_control::out_buffer`
+- `ntl::device_control::dispatch_fn`
+
+## RPC
+
+헤더:
+
+- [`include/ntl/rpc/common`](../include/ntl/rpc/common)
+- [`include/ntl/rpc/server`](../include/ntl/rpc/server)
+- [`include/ntl/rpc/client`](../include/ntl/rpc/client)
+
+RPC helper는 `DeviceIoControl` 기반의 server/client stub을 생성합니다.
+직렬화는 `zpp::serializer`를 사용합니다.
+
+주요 macro:
+
+- `NTL_RPC_BEGIN(name)`
+- `NTL_RPC_END(name)`
+- `NTL_ADD_CALLBACK_0`
+- `NTL_ADD_CALLBACK_1`
+- `NTL_ADD_CALLBACK_2`
+- `NTL_ADD_CALLBACK_3`
+- `NTL_ADD_CALLBACK_4`
+- `NTL_ADD_CALLBACK_5`
+
+타입:
+
+- `ntl::rpc::server`
+  - kernel-mode RPC device holder입니다.
+- `ntl::rpc::client`
+  - user-mode client입니다.
+  - `invoke<Ret>(index, args...)`를 제공합니다.
+
+전체 예시는 [`test/common/rpc.hpp`](../test/common/rpc.hpp)를 참고하세요.
+
+## IRQL
+
+헤더: [`include/ntl/irql`](../include/ntl/irql)
+
+`ntl::irql`은 주요 `KIRQL` 값을 감싸는 enum입니다.
+
+Helper:
+
+- `ntl::raised_irql`
+  - destructor에서 IRQL을 낮추는 RAII 객체입니다.
+- `ntl::raise_irql(KIRQL)`
+- `ntl::raise_irql_to_dpc_level()`
+- `ntl::raise_irql_to_synch_level()`
+- `ntl::current_irql()`
+
+## Spin Lock
+
+헤더: [`include/ntl/spin_lock`](../include/ntl/spin_lock)
+
+`ntl::spin_lock`은 `KSPIN_LOCK`을 감쌉니다.
+
+- `try_lock()`
+- `lock()`
+- `unlock()`
+- `lock_at_dpc_level()`
+- `unlock_from_dpc_level()`
+- `test()`
+- `native_handle()`
+
+`ntl::unique_lock<ntl::spin_lock>`은 `std::unique_lock`을 확장하며
+`ntl::at_dpc_level_lock`을 지원합니다.
+
+## ERESOURCE
+
+헤더: [`include/ntl/resource`](../include/ntl/resource)
+
+`ntl::resource`는 `ERESOURCE`를 감쌉니다.
+
+- `try_lock()`
+- `try_lock_shared()`
+- `lock()`
+- `unlock()`
+- `lock_shared()`
+- `unlock_shared()`
+- `locked() const`
+- `locked_exclusive() const`
+- `locked_shared() const`
+- `lock_no_critical_region(bool wait = true)`
+- `lock_shared_no_critical_region(bool wait = true)`
+- `unlock_no_critical_region()`
+- `unlock_shared_no_critical_region()`
+- `convert_to_shared()`
+- `waiter_count() const`
+- `shared_waiter_count() const`
+- `native_handle()`
+
+Lock helper:
+
+- `ntl::unique_lock<ntl::resource>`
+- `ntl::shared_lock<ntl::resource>`
+- `ntl::adopt_critical_region`
+
+## Unicode String
+
+헤더: [`include/ntl/unicode_string`](../include/ntl/unicode_string)
+
+`ntl::unicode_string`은 `std::wstring`을 `UNICODE_STRING`으로 사용할 수 있게
+도와줍니다.
+
+- `std::wstring`으로 생성
+- `c_str() const`
+- `operator*()`

--- a/docs/ko-kr.md
+++ b/docs/ko-kr.md
@@ -1,371 +1,228 @@
 # crtsys
 
-**C**/C++ Run**t**ime library for **sys**tem file (Windows Kernel Driver)
+Windows 커널 드라이버(`.sys`)를 위한 **C**/C++ Run**t**ime 지원
+라이브러리입니다.
 
 [![CMake](https://github.com/ntoskrnl7/crtsys/actions/workflows/cmake.yml/badge.svg)](https://github.com/ntoskrnl7/crtsys/actions/workflows/cmake.yml)
 ![GitHub](https://img.shields.io/github/license/ntoskrnl7/crtsys)
-![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/ntoskrnl7/crtsys)
-![Windows 7+](https://img.shields.io/badge/Windows-7+-blue?logo=windows&logoColor=white)
-![Visual Studio 2017+](https://img.shields.io/badge/Visual%20Studio-2017+-682270?logo=visualstudio&logoColor=682270)
-![CMake 3.14+](https://img.shields.io/badge/CMake-3.14+-yellow.svg?logo=cmake&logoColor=white)
-![C++ 14+](https://img.shields.io/badge/C++-14+-white.svg?logo=cplusplus&logoColor=blue)
-![Architecture](https://img.shields.io/badge/CPU-x86%20%2F%20x64%20%2F%20ARM%20%2F%20ARM64-blue.svg?logo=data:image/svg+xml;base64,PD94bWwgdmVyc2lvbj0iMS4wIj8+CjxzdmcgZW5hYmxlLWJhY2tncm91bmQ9Im5ldyAwIDAgNTIgNTIiIGlkPSJMYXllcl8xIiB2ZXJzaW9uPSIxLjEiIHZpZXdCb3g9IjAgMCA1MiA1MiIgeG1sOnNwYWNlPSJwcmVzZXJ2ZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxuczp4bGluaz0iaHR0cDovL3d3dy53My5vcmcvMTk5OS94bGluayI+CiAgICA8Zz4KICAgICAgICA8cGF0aCBmaWxsPSJ3aGl0ZSIgZD0iTTQ5LDE5LjV2LTJoLTYuOTk4NDEzMXYtNy40OTU3ODg2SDE0LjQwMTYxMTNsLTQuNDAwMDI0NCw0LjUzMDAyOTN2MjcuNDY5OTcwN0gxNy41VjQ5aDJ2LTYuOTk1Nzg4NmgzVjQ5aDJ2LTYuOTk1Nzg4NmgzICAgVjQ5aDJ2LTYuOTk1Nzg4NmgzVjQ5aDJ2LTYuOTk1Nzg4NmgyLjgxMTU4NDVsNC42OTAwMDI0LTUuNjQwMDE0NlYzNC41SDQ5di0yaC02Ljk5ODQxMzF2LTNINDl2LTJoLTYuOTk4NDEzMXYtM0g0OXYtMmgtNi45OTg0MTMxICAgdi0zSDQ5eiBNMzYuMDAxNTg2OSwzMy41MDQyMTE0YzAsMS42NTAwMjQ0LTEuMzQ5OTc1NiwzLTMsM2gtMTRjLTEuNjU5OTczMSwwLTMtMS4zNDk5NzU2LTMtM3YtMTRjMC0xLjY1OTk3MzEsMS4zNDAwMjY5LTMsMy0zaDE0ICAgYzEuNjUwMDI0NCwwLDMsMS4zNDAwMjY5LDMsM1YzMy41MDQyMTE0eiIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSIyIiB3aWR0aD0iNyIgeD0iMyIgeT0iMTcuNSIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSIyIiB3aWR0aD0iNyIgeD0iMyIgeT0iMjIuNSIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSIyIiB3aWR0aD0iNyIgeD0iMyIgeT0iMjcuNSIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSIyIiB3aWR0aD0iNyIgeD0iMyIgeT0iMzIuNSIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSI3IiB3aWR0aD0iMiIgeD0iMzIuNSIgeT0iMyIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSI3IiB3aWR0aD0iMiIgeD0iMjcuNSIgeT0iMyIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSI3IiB3aWR0aD0iMiIgeD0iMjIuNSIgeT0iMyIgLz4KICAgICAgICA8cmVjdCBzdHlsZT0iZmlsbDp3aGl0ZSIgaGVpZ2h0PSI3IiB3aWR0aD0iMiIgeD0iMTcuNSIgeT0iMyIgLz4KICAgIDwvZz4KPC9zdmc+)
-
-* [한국어](../docs/ko-kr.md)
-
-**crtsys**는 커널 드라이버에서 C++ CRT 및 STL 기능을 사용할 수 있도록 도와주는 오픈소스 라이브러리입니다.
-
-- [crtsys](#crtsys)
-  - [Overview](#overview)
-  - [Goal](#goal)
-    - [C++ Standard](#c-standard)
-      - [STL](#stl)
-    - [C Standard](#c-standard-1)
-    - [NTL (NT Template Library)](#ntl-nt-template-library)
-  - [Requirements](#requirements)
-  - [Test Environments](#test-environments)
-  - [Build & Test](#build--test)
-  - [Usage](#usage)
-  - [TODO](#todo)
-
-## Overview
-
-이 프로젝트는 유사한 프로젝트 중 가장 많은 C++ STL 기능을 지원합니다.
-
-<details>
-<summary>more</summary>
-
-커널 드라이버에서 C++ 및 STL을 사용할수있도록 도와주는 기능을 조사해보았는데, 그중 사용하기 가장 잘 구현되어있는 프로젝트는 아래와 같습니다.
-
-(22-04-26 기준)
-
-* [UCXXRT](https://github.com/MiroKaku/ucxxrt)
-  * 장점
-    * 타 프로젝트와는 다르게 [Microsoft STL](https://github.com/microsoft/STL)를 직접 사용한다는 개념 자체가 좋아보임.
-  * 단점
-    * 현재까지는 Win32 API와 연관성이 적은 std::string, std::vector 클래스 등 자료형이나 자료구조 관련 기능만 지원됨.
-    * vcxproj이 개발 환경에 종속되기 때문에 VS 버전이 바뀌면 일일이 수작업으로 수정해줘야함.
-    * x86에서 [이 코드](https://en.cppreference.com/w/cpp/language/throw#Example)를 실행하는 중 Hang이 발생함
-    * Microsoft의 소스 코드를 그대로 복사하여 상단에 자신의 라이센스 주석만 넣어서 프로젝트에 포함시킨것으로 보이며 라이센스 문제에서 자유롭지 못해보임
-      * 라이센스를 변경하는 것과 Microsoft CRT 및 STL 소스 코드를 재배포하는 행위는 허가되지 않은것으로 파악됨
-
-* [KTL](https://github.com/DymOK93/KTL)
-  * 장점
-    * CMake 사용됨
-      * 개발 환경에 맞는 프로젝트 파일 생성 및 자동화가 용이함
-    * CRT를 포함한 모든 코드를 독자적으로 구현
-      * 라이센스로부터 자유로우며, 예외처리 코드 부분이 경량화되어 스택을 절약할 수 있음
-    * 커널에 특화된 템플릿 라이브러리 제공
-      * 커널에서만 존재하는 매커니즘에 대한 템플릿 라이브러리를 제공하기 때문에, 실제 드라이버 제작 시에는 STL을 보다도 더 애용할만한 기능이 많음
-    * 높은 품질의 코드
-  * 단점
-    * Microsoft STL을 사용하는 것을 고려해서 작성된것으로 보이나 실제로 Microsoft STL을 사용하도록 변경하는 것에 어려움을 느낌 (오탈자 및 ktl 만 사용하는 코드가 생각보다 많았음)
-    * 러시아어 주석인데 파일이 UTF8+BOM로 인코딩되어있지 않아서 러시아 외 국가 환경에서 빌드를 실패함
-    * x86 미지원
-
-각 라이브러리의 단점을 보완하는 작업을 진행하던 중
-
-1. UCXXRT은 Microsoft CRT 소스 코드를 그대로 복사하여 프로젝트에 포함시켰다는 점
-2. KTL은 x86을 지원하지 않는 점
-
-으로 인해서 새로운 라이브러리를 개발하게 되었습니다.
-
-crtsys의 장점은 아래와 같습니다.
-
-1. Micosoft CRT와 STL을 최대한 비슷하게 지원하기 위해서 Microsoft CRT 소스코드를 사용하긴 하지만 Microsoft Visual Studio 혹은 Build Tools가 설치되어있는 디렉토리 내의 소스를 직접 빌드하는 방법으로 처리하여, Visual Studio를 합법적으로 사용하는 사용자는 라이센스 문제 없이 사용 가능합니다.
-2. Win32 API를 구현한 [Ldk](https://github.com/ntoskrnl7/Ldk)를 활용하여 많은 범위의 STL 기능을 지원합니다.
-3. CMake로 프로젝트를 구성할 수 있으며, [CPM](https://github.com/cpm-cmake/CPM.cmake)을 사용하여 정말 간편하게 라이브러리를 사용할 수 있도록 지원합니다.
-
-</details>
-
-## Goal
-
-이 프로젝트는 커널 드라이버를 작성할 때 애플리케이션에서 C++ 및 STL을 사용하는 것과 유사한 개발 경험을 제공하는 것을 목표로 합니다.
-
-현재 지원되거나 향후 지원되는 기능은 다음과 같습니다.
-
-* 체크된 항목은 구현된 항목입니다.
-* 테스트 코드가 작성된 항목의 경우 테스트 코드에 대한 링크가 추가되었습니다.
-
-### C++ Standard
-
-테스트 코드는 [C++ reference](https://en.cppreference.com)를 기반으로 작성되었습니다.
-
-* [Initialization](https://en.cppreference.com/w/cpp/language/initialization)
-  * [x] [Non-local variables](https://en.cppreference.com/w/cpp/language/initialization#Non-local_variables)
-    * [x] [Static initialization](https://en.cppreference.com/w/cpp/language/initialization#Static_initialization)
-      * [x] [Constant initialization](https://en.cppreference.com/w/cpp/language/constant_initialization) [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L13)
-      * [x] [Zero initialization](https://en.cppreference.com/w/cpp/language/zero_initialization) [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L41)
-    * [x] [Dynamic initialization](https://en.cppreference.com/w/cpp/language/initialization#Dynamic_initialization) [(tested)](../test/driver/src/cpp/lang/initialization.cpp#L65)
-  * [ ] [Static local variables](https://en.cppreference.com/w/cpp/language/storage_duration#Static_local_variables)
-    * [ ] thread_local
-    * [ ] static
-* [Exceptions](https://en.cppreference.com/w/cpp/language/exceptions)
-  * [x] [throw](https://en.cppreference.com/w/cpp/language/throw) [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L42)
-  * [x] [try-block](https://en.cppreference.com/w/cpp/language/try_catch) [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L60)
-  * [x] [Function-try-block](https://en.cppreference.com/w/cpp/language/function-try-block) [(tested)](../test/driver/src/cpp/lang/exceptions.cpp#L98)
-
-#### STL
-
-* [x] [std::chrono](https://en.cppreference.com/w/cpp/chrono) [(tested)](../test/driver/src/cpp/stl/chrono.cpp#L15)
-* [x] [std::thread](https://en.cppreference.com/w/cpp/thread) [(tested)](../test/driver/src/cpp/stl/thread.cpp#L35)
-* [x] [std::condition_variable](https://en.cppreference.com/w/cpp/thread/condition_variable) [(tested)](../test/driver/src/cpp/stl/thread.cpp#L35)
-* [x] [std::mutex](https://en.cppreference.com/w/cpp/thread/mutex) [(tested)](../test/driver/src/cpp/stl/thread.cpp#L81)
-* [x] [std::shared_mutex](https://en.cppreference.com/w/cpp/thread/shared_mutex) [(tested)](../test/driver/src/cpp/stl/thread.cpp#L129)
-* [x] [std::future](https://en.cppreference.com/w/cpp/thread/future) [(tested)](../test/driver/src/cpp/stl/thread.cpp#L157)
-* [x] [std::promise](https://en.cppreference.com/w/cpp/thread/promise) [(tested)](../test/driver/src/cpp/stl/thread.cpp#L203)
-* [x] [std::packaged_task](https://en.cppreference.com/w/cpp/thread/packaged_task) [(tested)](../test/driver/src/cpp/stl/thread.cpp#L267)
-* [x] [std::cin](https://en.cppreference.com/w/cpp/io/cin)
-* [x] [std::clog](https://en.cppreference.com/w/cpp/io/clog)
-* [x] [std::cerr](https://en.cppreference.com/w/cpp/io/cerr)
-* [x] [std::cout](https://en.cppreference.com/w/cpp/io/cout) (tested)
-* [x] [std::wcin](https://en.cppreference.com/w/cpp/io/cin)
-* [x] [std::wclog](https://en.cppreference.com/w/cpp/io/clog)
-* [x] [std::wcerr](https://en.cppreference.com/w/cpp/io/cerr)
-* [x] [std::wcout](https://en.cppreference.com/w/cpp/io/cout) (tested)
-
-### C Standard
-
-* [x] math functions
-  * 직접 구현하기에는 시간이 부족하여 아래 프로젝트의 내용을 참고하엿습니다. 감사합니다! :-)
-  * [RetrievAL](https://github.com/SpoilerScriptsGroup/RetrievAL)
-  * [musl](https://github.com/bminor/musl)
-
-### NTL (NT Template Library)
-
-커널에서 더 나은 개발 환경을 지원하기 위한 기능을 제공합니다.
-
-* ntl::expand_stack [(tested)](../test/src/ntl.cpp#L5)
-  * 스택 크기를 확장하기 위한 함수
-  * 기본적으로 커널 스택은 사용자 스레드 스택보다 훨씬 작은 크기를 할당받기 때문에 STL 기능을 사용하거나, 특히 throw를 수행할때 사용하는것이 좋습니다.
-* ntl::status
-  * NTSTATUS에 대한 클래스
-* ntl::driver
-  * DRIVER_OBJECT에 대한 클래스
-  * 기능
-    * [x] DriverUnload [(tested)](../test/driver/src/main.cpp#L73)
-    * [x] Create device [(tested)](../test/driver/src/main.cpp#L44)
-* ntl::device
-  * DEVICE_OBJECT에 대한 클래스
-  * 기능
-    * [x] Device Extension [(tested)](../test/driver/src/main.cpp#L33)
-    * [ ] IRP_MJ_CREATE
-    * [ ] IRP_MJ_CLOSE
-    * [x] IRP_MJ_DEVICE_CONTROL [(tested)](../test/app/src/main.cpp#L77) [(tested)](../test/driver/src/main.cpp#L55)
-* ntl::driver_main [(tested)](../test/driver/src/main.cpp#L25)
-  * C++ 용 드라이버 진입점
-  * ntl::expand_stack 함수로 스택을 최대 크기로 확장하여 호출됩니다.
-* ntl::rpc
-  * User Mode App과 Kernel Driver간 손쉬운 통신 방법을 제공합니다.
-    * ntl::rpc::server [(tested)](../test/driver/src/main.cpp#L19) [(tested)](../test/common/rpc.hpp)
-    * ntl::rpc::client [(tested)](../test/app/src/main.cpp#L4) [(tested)](../test/common/rpc.hpp)
-      * 데이터 직렬화 부분을 직접 구현하기에는 시간이 부족하여 아래 프로젝트 내용을 참고했습니다. 감사합니다! :-)
-        * [Eyal Z/zpp serializer](https://github.com/eyalz800/serializer)
-* ntl::irql
-  * KIRQL에 대한 클래스
-  * 클래스
-    * ntl::irql [(tested)](../test/driver/src/ntl.cpp#L46)
-  * 함수
-    * ntl::raise_irql [(tested)](../test/driver/src/ntl.cpp#L49)
-    * raise_irql_to_dpc_level [(tested)](../test/driver/src/ntl.cpp#L62)
-    * raise_irql_to_synch_level [(tested)](../test/driver/src/ntl.cpp#L71)
-* ntl::spin_lock
-  * KSPIN_LOCK에 대한 클래스
-  * 클래스
-    * ntl::spin_lock [(tested)](../test/driver/src/ntl.cpp#L80)
-    * ntl::unique_lock [(tested)](../test/driver/src/ntl.cpp#L99)
-* ntl::resource
-  * ERESOURCE에 대한 클래스
-  * 클래스
-    * ntl::resource [(tested)](../test/driver/src/ntl.cpp#L117)
-    * ntl::unique_lock [(tested)](../test/driver/src/ntl.cpp#L156)
-    * ntl::shared_lock [(tested)](../test/driver/src/ntl.cpp#L179)
-
-## Requirements
-
-* Windows 7 이상
-* [Visual Studio / Build Tools 2017 이상](https://visualstudio.microsoft.com/ko/downloads/)
-* [CMake 3.16 이상](https://cmake.org/download/)
-* [Git](https://git-scm.com/downloads)
-
-## Test Environments
-
-* Windows 10 x64
-  * **x86, x64, ARM, ARM64**로 빌드 가능하지만, 실제 테스트는 x86, x64 모듈에 대해서만 검증되었습니다.
-
-* CMake 3.21.4
-* Git 2.23.0
-* Visual Studio 2017
-  * Visual Studio 2017의 CRT 소스 코드는 일부 헤더가 누락되어 빌드가 되지 않아서, UCXXRT의 코드를 일부 사용하여 지원합니다.
-  * 추후 누락된 헤더를 직접 작성하여 지원할 예정입니다.
-* Visual Studio 2019
-* Visual Studio 2022
-* VC Tools
-  * 14.16.27023
-  * 14.24.28314
-  * 14.26.28801
-  * 14.29.30133
-  * 14.31.31103
-  * 14.33.31629
-* Windows Kits (SDK, WDK)
-  * 10.0.17763.0
-  * 10.0.18362.0
-  * 10.0.22000.0
-  * 10.0.22621.0
-
-SDK와 WDK의 버전이 다르면 빌드가 실패할 가능성이 높으므로 **가능하다면 SDK와 WDK의 버전이 같은 환경에서 빌드하는것을 권장합니다.**
-
-## Build & Test
-
-1. 아래 명령을 수행하여 라이브러리 및 테스트 코드를 빌드하시기 바랍니다.
-
-    ```Batch
-    git clone https://github.com/ntoskrnl7/crtsys
-    cd crtsys\test\build.bat
-    ```
-
-    혹은 아래 명령을 수행하시면 지원되는 모든 아키텍쳐에 대해서 Debug, Release 구성을 모두 빌드합니다.
-
-    ```Batch
-    git clone https://github.com/ntoskrnl7/crtsys
-    cd crtsys
-    build_all.bat test\app
-    build_all.bat test\driver
-    ```
-
-2. build\Debug\crtsys_test.sys를 설치 및 로드하시기 바랍니다.
-
-   * driver
-    x64 : test\driver\build_x64\Debug\crtsys_test.sys
-    x86 : test\driver\build_x86\Debug\crtsys_test.sys
-    ARM : test\driver\build_ARM\Debug\crtsys_test.sys
-    ARM64 : test\driver\build_ARM64\Debug\crtsys_test.sys
-   * app
-    x64 : test\driver\build_x64\Debug\crtsys_test_app.exe
-    x86 : test\driver\build_x86\Debug\crtsys_test_app.exe
-    ARM : test\driver\build_ARM\Debug\crtsys_test_app.exe
-    ARM64 : test\driver\build_ARM64\Debug\crtsys_test_app.exe
-
-   ```batch
-   sc create CrtSysTest binpath= "crtsys_test.sys full path" displayname= "crtsys test" start= demand type= kernel
-   sc start CrtSysTest
-
-   crtsys_test.app.exe
-
-   sc stop CrtSysTest
-   sc delete CrtSysTest
-   ```
-
-3. 정상적으로 로드, Google Test 통과/언로드가 되었다면 테스트 성공한 것이며, 테스트 내용은 DebugView나 WinDbg를 통해서 확인 가능합니다.
-
-## Usage
-
-1. 프로젝트 디렉토리를 생성 후 이동하시기 바랍니다.
-
-   ```batch
-   mkdir test-project
-   cd test-project
-   ```
-
-2. CPM을 프로젝트 디렉토리에 다운로드 받으시기 바랍니다.
-
-    ```batch
-    mkdir cmake
-    wget -O cmake/CPM.cmake https://github.com/cpm-cmake/CPM.cmake/releases/latest/download/get_cpm.cmake
-    ```
-
-    혹은
-
-    ```batch
-    mkdir cmake
-    curl -o cmake/CPM.cmake -LJO https://github.com/cpm-cmake/CPM.cmake/releases/latest/download/get_cpm.cmake
-    ```
-
-3. 프로젝트 디렉토리에 아래와 같은 파일을 작성해주시기 바랍니다.
-
-   * 디렉토리 구조
-
-      ```tree
-      📦test-project
-      ┣ 📂src
-      ┃ ┗ 📜main.cpp
-      ┗ 📜CMakeLists.txt
-      ```
-
-   * CMakeLists.txt
-
-        ```CMake
-        cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
-
-        project(crtsys_test LANGUAGES C CXX)
-
-        include(cmake/CPM.cmake)
-
-        set(CRTSYS_NTL_MAIN ON) # use ntl::main
-        CPMAddPackage("gh:ntoskrnl7/crtsys@0.1.10")
-        include(${crtsys_SOURCE_DIR}/cmake/CrtSys.cmake)
-
-        # add driver
-        crtsys_add_driver(crtsys_test src/main.cpp)
-        ```
-
-   * src/main.cpp
-
-        * 아래와 같이 CRTSYS_NTL_MAIN을 활성화한다면 ntl::main을 진입점으로 정의하시기 바랍니다. **(권장)**
-
-          * CMakeLists.txt
-
-              ```CMake
-              set(CRTSYS_NTL_MAIN ON)
-              ```
-
-        * 만약 아래와 같이 CRTSYS_NTL_MAIN을 비활성화한다면 기존과 깉이 DriverEntry를 진입점으로 정의하시기 바랍니다.
-
-          * CMakeLists.txt
-
-              ```CMake
-              set(CRTSYS_NTL_MAIN OFF)
-              ```
-
-        아래는 ntl::main를 진입점으로 설정한 프로젝트의 예제 코드입니다.
-
-        ```C
-        #include <iostream>
-        #include <ntl/driver>
-
-        ntl::status ntl::main(ntl::driver &driver, const std::wstring &registry_path) {
-
-          std::wcout << "load (registry_path :" << registry_path << ")\n";
-
-          // TODO
-
-          driver.on_unload([registry_path]() {
-            std::wcout << "unload (registry_path :" << registry_path << ")\n";
-          });
-
-          return status::ok();
-        }
-        ```
-
-4. 빌드를 수행합니다.
-
-   ```batch
-   cmake -S . -B build
-   cmake --build build
-   ```
-
-5. 드라이버가 정상적으로 시작되고 종료되는지 확인하시기 바랍니다.
-
-   ```batch
-   sc create CrtSysTest binpath= "crtsys_test.sys full path" displayname= "crtsys test" start= demand type= kernel
-   sc start CrtSysTest
-   sc stop CrtSysTest
-   sc delete CrtSysTest
-   ```
-
-## TODO
-
-* CMake install 처리.
-* 아직 구현되지 않은 C++ 및 STL 기능 구현
-* Visual Studio 2017의 CRT 소스 코드 빌드
-* GitHub Action에서 단위 테스트 실행
+![GitHub release](https://img.shields.io/github/v/release/ntoskrnl7/crtsys)
+![Windows 7+](https://img.shields.io/badge/Windows-7%2B-blue?logo=windows&logoColor=white)
+![Visual Studio 2017+](https://img.shields.io/badge/Visual%20Studio-2017%2B-682270?logo=visualstudio&logoColor=white)
+![CMake 3.14+](https://img.shields.io/badge/CMake-3.14%2B-064f8c?logo=cmake&logoColor=white)
+![C++14+](https://img.shields.io/badge/C%2B%2B-14%2B-00599c?logo=cplusplus&logoColor=white)
+
+[English documentation](../README.md)
+
+`crtsys`는 Windows 커널 드라이버에서 C++ 언어 기능, 일부 Microsoft STL
+기능, 그리고 커널에 맞춘 작은 C++ 헬퍼들을 사용할 수 있도록 돕는 실험적
+런타임 레이어입니다. WDK와 CMake 기반 빌드 흐름은 유지하면서, 드라이버
+코드에서 더 익숙한 C++ 개발 경험을 제공하는 것을 목표로 합니다.
+
+프로젝트는 크게 세 부분으로 구성됩니다.
+
+- 커널 모드 빌드를 위한 CRT/STL 호환 코드.
+- 런타임과 STL이 필요로 하는 일부 Win32/NTDLL 유사 API를 제공하는
+  [`Ldk`](https://github.com/ntoskrnl7/ldk).
+- 드라이버 객체와 동기화 코드를 C++ 스타일로 감싸는 NTL 헬퍼.
+
+## 상태
+
+이 프로젝트는 완전한 사용자 모드 CRT도, 완전한 Windows 호환 레이어도,
+드라이버 설계를 대신해주는 도구도 아닙니다. 커널 모드에서 유용한 C++ 및
+STL 시나리오를 가능하게 해주지만, 실제 드라이버는 배포 대상 Windows,
+WDK, SDK, Visual Studio, 아키텍처, Driver Verifier 설정에서 반드시 따로
+검증해야 합니다.
+
+현재 알려진 제약은 다음과 같습니다.
+
+- Thread-local storage와 thread-safe local static initialization은 아직
+  지원하지 않습니다.
+- 커널 스택은 작습니다. 예외 처리나 STL 사용으로 스택을 많이 쓰는 경로는
+  `ntl::expand_stack` 사용을 고려하세요.
+- SDK와 WDK 버전이 다르면 빌드가 실패할 수 있습니다. 가능하면 같은 버전의
+  SDK와 WDK를 사용하세요.
+- Windows 11 24H2 WDK부터는 x86 커널 모드 드라이버 개발을 지원하지
+  않습니다. x86 드라이버 대상이 필요하면 WDK 23H2 이하를 사용해야 합니다.
+
+## 기능
+
+README 계열 문서에서는 기능 목록을 짧게 유지합니다. 어떤 항목이 정확히
+테스트되었는지는 별도 문서에 테스트 링크와 함께 정리했습니다.
+
+- [상세 기능 지원 현황](./ko-kr-feature-coverage.md)
+- [NTL API 문서](./ko-kr-ntl-api.md)
+
+상위 수준의 지원 범위는 다음과 같습니다.
+
+- C++ 런타임 지원
+  - 비지역 static 초기화
+  - 동적 초기화
+  - 예외 처리
+- Microsoft STL 지원
+  - 시간 유틸리티
+  - 스레딩 primitive
+  - 동기화 primitive
+  - 비동기 primitive
+  - stream 객체
+- C 런타임 지원
+  - 지원되는 STL 경로에 필요한 CRT glue
+  - math helper
+  - floating-point classification helper
+- NTL 지원
+  - C++ 드라이버 진입점 래퍼
+  - driver/device helper
+  - RPC helper
+  - IRQL 및 동기화 helper
+
+## 요구 사항
+
+- Windows 7 이상
+- Visual Studio 또는 Build Tools 2017 이상
+- 선택한 Visual Studio toolset과 호환되는 Windows SDK 및 WDK
+- CMake 3.14 이상
+- Git
+
+테스트된 toolchain에는 Visual Studio 2017, 2019, 2022와 `10.0.17763.0`,
+`10.0.18362.0`, `10.0.22000.0`, `10.0.22621.0` SDK/WDK 계열이 포함됩니다.
+
+Visual Studio 2017은 일부 CRT 소스/헤더 구성이 부족한 경로가 있어서,
+해당 toolset에서는 일부 UCXXRT 호환 코드를 사용합니다.
+
+## 빠른 시작
+
+드라이버 프로젝트에 `cmake/CPM.cmake`를 배치한 뒤 `crtsys`를 추가합니다.
+
+```cmake
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+
+project(my_driver LANGUAGES C CXX)
+
+include(cmake/CPM.cmake)
+
+set(CRTSYS_NTL_MAIN ON)
+CPMAddPackage("gh:ntoskrnl7/crtsys@0.1.10")
+include(${crtsys_SOURCE_DIR}/cmake/CrtSys.cmake)
+
+crtsys_add_driver(my_driver src/main.cpp)
+```
+
+`CRTSYS_NTL_MAIN`을 켜면 C++ 진입점 래퍼를 사용합니다. 이 경우 직접
+`DriverEntry`를 작성하지 않고 `ntl::main`을 정의합니다.
+
+```cpp
+#include <iostream>
+#include <string>
+#include <ntl/driver>
+
+ntl::status ntl::main(ntl::driver& driver,
+                      const std::wstring& registry_path) {
+  std::wcout << L"load: " << registry_path << L"\n";
+
+  driver.on_unload([registry_path]() {
+    std::wcout << L"unload: " << registry_path << L"\n";
+  });
+
+  return ntl::status::ok();
+}
+```
+
+`CRTSYS_NTL_MAIN`을 끄면 일반 WDK 드라이버처럼 `DriverEntry`를 직접
+작성하고 초기화를 수동으로 처리하면 됩니다.
+
+Visual Studio generator로 빌드합니다.
+
+```bat
+cmake -S . -B build_x64 -A x64
+cmake --build build_x64 --config Debug
+```
+
+## 이 저장소 빌드
+
+저장소를 clone한 뒤, 현재 호스트 아키텍처 기준으로 테스트 앱과 드라이버를
+빌드합니다.
+
+```bat
+git clone https://github.com/ntoskrnl7/crtsys
+cd crtsys
+test\build.bat
+```
+
+특정 대상을 직접 빌드하려면 다음처럼 실행합니다.
+
+```bat
+build.bat test\app x64 Debug
+build.bat test\driver x64 Debug
+build.bat test\app x64 Release
+build.bat test\driver x64 Release
+```
+
+지원하는 모든 아키텍처와 구성 조합을 빌드하려면 다음 명령을 사용합니다.
+
+```bat
+build_all.bat test\app
+build_all.bat test\driver
+```
+
+일반적인 Debug 출력 경로는 다음과 같습니다.
+
+```text
+test\driver\build_x64\Debug\crtsys_test.sys
+test\app\build_x64\Debug\crtsys_test_app.exe
+```
+
+## 테스트 실행
+
+`crtsys_test.sys`는 커널 드라이버입니다. CI에서는 빌드 검증만 할 수 있고,
+실제 로드와 실행은 Windows 드라이버 테스트 환경에서 수행해야 합니다.
+
+CI 빌드 workflow와 선택적 self-hosted 드라이버 로드 테스트 경로는
+[CI driver load tests](./ci-driver-load-tests.md)에 정리되어 있습니다.
+
+```bat
+sc create CrtSysTest binpath= "C:\path\to\crtsys_test.sys" displayname= "crtsys test" start= demand type= kernel
+sc start CrtSysTest
+
+C:\path\to\crtsys_test_app.exe
+
+sc stop CrtSysTest
+sc delete CrtSysTest
+```
+
+테스트 드라이버는 내부적으로 Google Test를 사용합니다. 결과는 DebugView,
+WinDbg 또는 일반적인 커널 디버깅 환경에서 확인하세요.
+
+## 저장소 구조
+
+```text
+cmake/             CrtSys.cmake를 포함한 CMake 헬퍼
+include/ntl/       NTL C++ 헬퍼 헤더
+include/.internal/ 내부 버전 및 toolchain 호환 헤더
+src/               crtsys 런타임 및 CRT/STL 호환 코드
+test/app/          사용자 모드 테스트 companion 앱
+test/driver/       커널 모드 테스트 드라이버
+docs/              추가 문서
+```
+
+## 배경
+
+`crtsys`는 UCXXRT와 KTL 같은 커널 C++ 런타임 프로젝트를 실험한 뒤 만들어진
+프로젝트입니다. 목표는 CMake/WDK 흐름을 실용적으로 유지하면서 실제 드라이버
+실험에 충분한 Microsoft CRT/STL 동작을 지원하는 것입니다.
+
+프로젝트는 Microsoft CRT/STL 소스를 vendored library처럼 다루지 않으려는
+방향으로 설계되었습니다. 대신 로컬에 설치된 Visual Studio/Build Tools의
+구성과 작은 커널 모드 호환 코드를 함께 사용합니다. Microsoft가 제공하는
+소스/헤더 구성이 부족한 오래된 toolset에서는 일부 호환 코드를 사용합니다.
+
+아래 프로젝트의 구현도 필요한 곳에서 참고했습니다.
+
+- [RetrievAL](https://github.com/SpoilerScriptsGroup/RetrievAL)
+- [musl](https://github.com/bminor/musl)
+- [zpp serializer](https://github.com/eyalz800/serializer)
+
+## 로드맵
+
+- CMake install/package 처리 추가.
+- 아직 지원하지 않는 C++ 및 STL 기능 확장.
+- Visual Studio 2017 호환성 간격 축소.
+- 환경이 허용하는 경우 실제 드라이버 로드/실행 테스트의 CI 적용.

--- a/docs/ntl-api.md
+++ b/docs/ntl-api.md
@@ -1,0 +1,219 @@
+# NTL API Reference
+
+[Back to README](../README.md)
+
+NTL is the small C++ helper layer shipped with `crtsys`. It is intended for
+kernel driver code that wants RAII-style ownership, callback registration, and
+simple user-mode to kernel-mode RPC without hiding the underlying WDK objects.
+
+Headers live under [`include/ntl`](../include/ntl).
+
+## Entry Point
+
+When `CRTSYS_NTL_MAIN` is enabled, implement:
+
+```cpp
+ntl::status ntl::main(ntl::driver& driver,
+                      const std::wstring& registry_path);
+```
+
+`crtsys` routes the WDK driver entry point into this function. The wrapper also
+uses the stack expansion helper before calling into `ntl::main`.
+
+## `ntl::status`
+
+Header: [`include/ntl/status`](../include/ntl/status)
+
+`ntl::status` wraps `NTSTATUS`.
+
+- `status(NTSTATUS status)`
+- `bool is_ok() const`
+- `bool is_info() const`
+- `bool is_warn() const`
+- `bool is_err() const`
+- `operator NTSTATUS() const`
+- `static status ok()`
+
+## Exceptions
+
+Header: [`include/ntl/except`](../include/ntl/except)
+
+- `ntl::exception`
+  - stores an `ntl::status`
+  - carries an explanatory message
+- `ntl::seh::try_except(fn, args...)`
+  - runs a callable inside SEH
+  - returns `{success, exception_code}`
+
+## Stack Expansion
+
+Header: [`include/ntl/expand_stack`](../include/ntl/expand_stack)
+
+Use `ntl::expand_stack` around call paths that may need more stack than the
+default kernel stack.
+
+```cpp
+auto opts = ntl::expand_stack_options().wait(true);
+auto result = ntl::expand_stack(std::move(opts), [] {
+  return do_expensive_work();
+});
+```
+
+API:
+
+- `ntl::expand_stack_size_max`
+- `ntl::expand_stack_options`
+  - `stack_size(size_t)`
+  - `wait(bool)`
+  - `ignore_failure(bool)`
+- `ntl::expand_stack(options, fn, args...)`
+
+## Driver Object
+
+Header: [`include/ntl/driver`](../include/ntl/driver)
+
+`ntl::driver` wraps `DRIVER_OBJECT`.
+
+- `create_device<Extension>(device_options&)`
+  - creates an `ntl::device<Extension>`
+  - constructs the extension object in the device extension area
+- `on_unload(callback)`
+  - registers a C++ unload callback
+- `name() const`
+  - returns the driver name as `std::wstring`
+
+## Device Object
+
+Header: [`include/ntl/device`](../include/ntl/device)
+
+`ntl::device_options` configures device creation.
+
+- `name(std::wstring)`
+- `type(DEVICE_TYPE)`
+- `exclusive(bool = true)`
+- `name() const`
+- `type() const`
+- `is_exclusive() const`
+
+`ntl::device<Extension>` owns a `PDEVICE_OBJECT`.
+
+- `extension()`
+  - returns the typed extension object
+- `on_device_control(callback)`
+  - registers an `IRP_MJ_DEVICE_CONTROL` handler
+- `name() const`
+- `type() const`
+- `detach()`
+  - releases ownership of the raw device object
+
+Device control helper types:
+
+- `ntl::device_control::code`
+- `ntl::device_control::in_buffer`
+- `ntl::device_control::out_buffer`
+- `ntl::device_control::dispatch_fn`
+
+## RPC
+
+Headers:
+
+- [`include/ntl/rpc/common`](../include/ntl/rpc/common)
+- [`include/ntl/rpc/server`](../include/ntl/rpc/server)
+- [`include/ntl/rpc/client`](../include/ntl/rpc/client)
+
+The RPC helpers generate matching server and client stubs around
+`DeviceIoControl`. Serialization uses `zpp::serializer`.
+
+Common macros:
+
+- `NTL_RPC_BEGIN(name)`
+- `NTL_RPC_END(name)`
+- `NTL_ADD_CALLBACK_0`
+- `NTL_ADD_CALLBACK_1`
+- `NTL_ADD_CALLBACK_2`
+- `NTL_ADD_CALLBACK_3`
+- `NTL_ADD_CALLBACK_4`
+- `NTL_ADD_CALLBACK_5`
+
+Types:
+
+- `ntl::rpc::server`
+  - kernel-mode holder for the RPC device
+- `ntl::rpc::client`
+  - user-mode client
+  - `invoke<Ret>(index, args...)`
+
+See [`test/common/rpc.hpp`](../test/common/rpc.hpp) for a complete shared RPC
+schema example.
+
+## IRQL
+
+Header: [`include/ntl/irql`](../include/ntl/irql)
+
+`ntl::irql` is an enum wrapper around common `KIRQL` values.
+
+Helpers:
+
+- `ntl::raised_irql`
+  - RAII object that lowers IRQL in its destructor
+- `ntl::raise_irql(KIRQL)`
+- `ntl::raise_irql_to_dpc_level()`
+- `ntl::raise_irql_to_synch_level()`
+- `ntl::current_irql()`
+
+## Spin Lock
+
+Header: [`include/ntl/spin_lock`](../include/ntl/spin_lock)
+
+`ntl::spin_lock` wraps `KSPIN_LOCK`.
+
+- `try_lock()`
+- `lock()`
+- `unlock()`
+- `lock_at_dpc_level()`
+- `unlock_from_dpc_level()`
+- `test()`
+- `native_handle()`
+
+`ntl::unique_lock<ntl::spin_lock>` extends `std::unique_lock` with
+`ntl::at_dpc_level_lock`.
+
+## ERESOURCE
+
+Header: [`include/ntl/resource`](../include/ntl/resource)
+
+`ntl::resource` wraps `ERESOURCE`.
+
+- `try_lock()`
+- `try_lock_shared()`
+- `lock()`
+- `unlock()`
+- `lock_shared()`
+- `unlock_shared()`
+- `locked() const`
+- `locked_exclusive() const`
+- `locked_shared() const`
+- `lock_no_critical_region(bool wait = true)`
+- `lock_shared_no_critical_region(bool wait = true)`
+- `unlock_no_critical_region()`
+- `unlock_shared_no_critical_region()`
+- `convert_to_shared()`
+- `waiter_count() const`
+- `shared_waiter_count() const`
+- `native_handle()`
+
+Lock helpers:
+
+- `ntl::unique_lock<ntl::resource>`
+- `ntl::shared_lock<ntl::resource>`
+- `ntl::adopt_critical_region`
+
+## Unicode String
+
+Header: [`include/ntl/unicode_string`](../include/ntl/unicode_string)
+
+`ntl::unicode_string` adapts `std::wstring` to `UNICODE_STRING`.
+
+- construct from `std::wstring`
+- `c_str() const`
+- `operator*()`


### PR DESCRIPTION
## Summary

- Rewrote the English `README.md` to present crtsys more clearly as a Windows kernel-mode C/C++ runtime support layer.
- Reworked `docs/ko-kr.md` with the same improved structure and more natural Korean wording.
- Kept the README feature section short, but moved the exact test-linked coverage checklist into dedicated docs:
  - `docs/feature-coverage.md`
  - `docs/ko-kr-feature-coverage.md`
- Added NTL API documentation:
  - `docs/ntl-api.md`
  - `docs/ko-kr-ntl-api.md`
- Preserved the CI driver load-test documentation link added on `main`.
- Fixed stale build/test instructions, including the incorrect `cd crtsys\test\build.bat` command and the test app output path.

## Notes

This PR is documentation-only and is now rebased on top of the merged GitHub Actions CI update from PR #26.

## Validation

- `git diff --check origin/main..HEAD` passes locally.
- Relative links in `README.md` and `docs/*.md` resolve locally.
- Searched the updated docs for removed stale phrases and old path mistakes.