### PR TITLE
[codex] add NuGet packaging workflow

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -1,0 +1,133 @@
+name: NuGet
+
+on:
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/nuget.yml'
+      - 'nuget/**'
+      - 'scripts/nuget/**'
+      - 'CMakeLists.txt'
+      - 'LICENSE'
+      - 'README.md'
+      - 'build.bat'
+      - 'build_all.bat'
+      - 'cmake/**'
+      - 'docs/**'
+      - 'include/**'
+      - 'src/**'
+  push:
+    branches: [ main ]
+    tags:
+      - 'v*'
+    paths:
+      - '.github/workflows/nuget.yml'
+      - 'nuget/**'
+      - 'scripts/nuget/**'
+      - 'CMakeLists.txt'
+      - 'LICENSE'
+      - 'README.md'
+      - 'build.bat'
+      - 'build_all.bat'
+      - 'cmake/**'
+      - 'docs/**'
+      - 'include/**'
+      - 'src/**'
+  workflow_dispatch:
+    inputs:
+      package_version:
+        description: Optional package version override
+        required: false
+        type: string
+      publish:
+        description: Publish the generated package to nuget.org
+        required: true
+        type: boolean
+        default: false
+
+permissions:
+  contents: read
+
+jobs:
+  pack:
+    name: Pack NuGet
+    runs-on: windows-2022
+    outputs:
+      package_version: ${{ steps.version.outputs.package_version }}
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - name: Resolve package version
+        id: version
+        shell: pwsh
+        run: |
+          $version = '${{ inputs.package_version }}'
+          if ([string]::IsNullOrWhiteSpace($version)) {
+            $version = ./scripts/nuget/Get-CrtSysVersion.ps1
+          }
+
+          if ($env:GITHUB_REF_TYPE -eq 'tag') {
+            if ($env:GITHUB_REF_NAME -notmatch '^v(.+)$') {
+              throw "Release tag must use v<version> format."
+            }
+
+            $tagVersion = $Matches[1]
+            if ($version -ne $tagVersion) {
+              throw "Package version '$version' does not match tag version '$tagVersion'."
+            }
+          }
+
+          "package_version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append
+          Write-Host "Package version: $version"
+
+      - name: Build prebuilt libraries
+        shell: pwsh
+        run: ./scripts/nuget/Build-CrtSysNuGetLibs.ps1 -Architecture x64,ARM64 -Configuration Release -WindowsSdkVersion '10.0.22621.0'
+
+      - name: Pack
+        shell: pwsh
+        run: ./scripts/nuget/Pack-CrtSysNuGet.ps1 -Version '${{ steps.version.outputs.package_version }}'
+
+      - uses: actions/upload-artifact@v7
+        with:
+          name: crtsys-nuget-${{ steps.version.outputs.package_version }}
+          path: artifacts/nuget/*.nupkg
+          if-no-files-found: error
+
+  publish:
+    name: Publish NuGet
+    needs: pack
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    runs-on: windows-2022
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.x'
+
+      - uses: actions/download-artifact@v7
+        with:
+          name: crtsys-nuget-${{ needs.pack.outputs.package_version }}
+          path: artifacts/nuget
+
+      - name: NuGet login
+        uses: NuGet/login@v1
+        id: nuget-login
+        with:
+          user: ntoskrnl7
+
+      - name: Publish to nuget.org
+        shell: pwsh
+        env:
+          NUGET_API_KEY: ${{ steps.nuget-login.outputs.NUGET_API_KEY }}
+        run: ./scripts/nuget/Push-CrtSysNuGet.ps1 -SkipDuplicate

--- a/README.md
+++ b/README.md
@@ -137,6 +137,70 @@ cmake -S . -B build_x64 -A x64
 cmake --build build_x64 --config Debug
 ```
 
+## NuGet Package
+
+`crtsys` can be distributed as a native NuGet package for Visual Studio driver
+projects. The package includes public NTL headers, internal compatibility
+headers, native MSBuild imports, and prebuilt `crtsys.lib`/`Ldk.lib` binaries.
+
+After installing the package in a Visual Studio WDK driver project, NuGet
+imports `build/native/crtsys.props` and `build/native/crtsys.targets`
+automatically. Those files add the include paths, forced include file,
+preprocessor definitions, library path, linker dependencies, and
+`CrtSysDriverEntry` entry point needed for the default `ntl::main` flow.
+The binary NuGet package currently supports the `ntl::main` entry point flow
+only.
+
+The current binary package targets:
+
+- Visual Studio 2022
+- Windows SDK/WDK `10.0.22621.0`
+- `x64` and `ARM64`
+- Release `crtsys.lib` and `Ldk.lib`
+
+Install it from Visual Studio's **Manage NuGet Packages** UI. In the Package
+Manager Console, select your driver project as the default project and run:
+
+```powershell
+Install-Package crtsys -Version 0.1.10
+```
+
+Then define `ntl::main` in your driver:
+
+```cpp
+#include <ntl/driver>
+
+ntl::status ntl::main(ntl::driver& driver,
+                      const std::wstring& registry_path) {
+  driver.on_unload([]() {});
+  return ntl::status::ok();
+}
+```
+
+For native MSBuild consumers, the package also exposes `$(CrtSysRoot)`.
+
+Pack locally:
+
+```powershell
+.\scripts\nuget\Build-CrtSysNuGetLibs.ps1
+.\scripts\nuget\Pack-CrtSysNuGet.ps1
+```
+
+Publish with an API key in the environment:
+
+```powershell
+$env:NUGET_API_KEY = '<nuget-api-key>'
+.\scripts\nuget\Push-CrtSysNuGet.ps1 -SkipDuplicate
+```
+
+GitHub Actions builds the prebuilt libraries and package on pull requests and
+pushes. A tag such as `v0.1.10` publishes to nuget.org through NuGet Trusted
+Publishing when the tag version matches `include/.internal/version`.
+
+For GitHub Actions publishing, create a nuget.org Trusted Publishing policy
+with repository owner `ntoskrnl7`, repository `crtsys`, workflow file
+`nuget.yml`, and no environment restriction.
+
 ## Building This Repository
 
 Clone the repository and build the test app and driver for the host

--- a/docs/ko-kr.md
+++ b/docs/ko-kr.md
@@ -136,6 +136,72 @@ cmake -S . -B build_x64 -A x64
 cmake --build build_x64 --config Debug
 ```
 
+## NuGet 패키지
+
+`crtsys`는 Visual Studio WDK 드라이버 프로젝트에서 바로 사용할 수 있는
+native NuGet 패키지로 배포할 수 있습니다. 패키지에는 공개 NTL 헤더, 내부
+호환성 헤더, native MSBuild import 파일, 미리 빌드된 `crtsys.lib`와
+`Ldk.lib`가 포함됩니다.
+
+Visual Studio WDK 드라이버 프로젝트에 패키지를 설치하면 NuGet이
+`build/native/crtsys.props`와 `build/native/crtsys.targets`를 자동으로
+import합니다. 이 파일들은 기본 `ntl::main` 흐름에 필요한 include 경로,
+forced include 파일, preprocessor 정의, library 경로, linker dependency,
+`CrtSysDriverEntry` entry point를 설정합니다.
+현재 binary NuGet 패키지는 `ntl::main` entry point 흐름만 지원합니다.
+
+현재 binary 패키지 대상은 다음과 같습니다.
+
+- Visual Studio 2022
+- Windows SDK/WDK `10.0.22621.0`
+- `x64` 및 `ARM64`
+- Release `crtsys.lib` 및 `Ldk.lib`
+
+Visual Studio의 **Manage NuGet Packages** UI에서 설치합니다. Package
+Manager Console을 사용할 때는 기본 프로젝트를 드라이버 프로젝트로 선택한 뒤
+다음 명령을 실행합니다.
+
+```powershell
+Install-Package crtsys -Version 0.1.10
+```
+
+그 뒤 드라이버에서 `ntl::main`을 정의합니다.
+
+```cpp
+#include <ntl/driver>
+
+ntl::status ntl::main(ntl::driver& driver,
+                      const std::wstring& registry_path) {
+  driver.on_unload([]() {});
+  return ntl::status::ok();
+}
+```
+
+native MSBuild 소비자를 위해 패키지는 `$(CrtSysRoot)` 속성도 제공합니다.
+
+로컬에서 패키지를 만들려면 다음 명령을 사용합니다.
+
+```powershell
+.\scripts\nuget\Build-CrtSysNuGetLibs.ps1
+.\scripts\nuget\Pack-CrtSysNuGet.ps1
+```
+
+환경 변수에 API key가 있을 때 publish할 수 있습니다.
+
+```powershell
+$env:NUGET_API_KEY = '<nuget-api-key>'
+.\scripts\nuget\Push-CrtSysNuGet.ps1 -SkipDuplicate
+```
+
+GitHub Actions도 pull request와 push에서 prebuilt library와 패키지를
+생성합니다. `v0.1.10` 같은 태그를 push하면, 태그 버전이
+`include/.internal/version`과 일치할 때 NuGet Trusted Publishing을 통해
+nuget.org로 publish합니다.
+
+GitHub Actions publish를 사용하려면 nuget.org Trusted Publishing policy를
+repository owner `ntoskrnl7`, repository `crtsys`, workflow file `nuget.yml`,
+environment 제한 없음으로 생성합니다.
+
 ## 이 저장소 빌드
 
 저장소를 clone한 뒤, 현재 호스트 아키텍처 기준으로 테스트 앱과 드라이버를

--- a/nuget/build/native/crtsys.props
+++ b/nuget/build/native/crtsys.props
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CrtSysRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..'))</CrtSysRoot>
+    <CrtSysLibPlatform Condition="'$(Platform)' == 'Win32'">x86</CrtSysLibPlatform>
+    <CrtSysLibPlatform Condition="'$(CrtSysLibPlatform)' == ''">$(Platform)</CrtSysLibPlatform>
+    <CrtSysLibraryConfiguration Condition="'$(CrtSysLibraryConfiguration)' == ''">Release</CrtSysLibraryConfiguration>
+    <CrtSysLibDir>$(CrtSysRoot)lib\native\$(CrtSysLibPlatform)\$(CrtSysLibraryConfiguration)\</CrtSysLibDir>
+    <CrtSysUseNtlMain Condition="'$(CrtSysUseNtlMain)' == ''">true</CrtSysUseNtlMain>
+    <CrtSysPreprocessorDefinitions>_KERNEL32_;_ITERATOR_DEBUG_LEVEL=0;_HAS_EXCEPTIONS</CrtSysPreprocessorDefinitions>
+    <CrtSysPreprocessorDefinitions Condition="'$(CrtSysUseNtlMain)' == 'true'">$(CrtSysPreprocessorDefinitions);CRTSYS_USE_NTL_MAIN</CrtSysPreprocessorDefinitions>
+    <CrtSysPreprocessorDefinitions Condition="'$(CrtSysLibPlatform)' == 'x64'">$(CrtSysPreprocessorDefinitions);CRTSYS_USE_LIBCNTPR</CrtSysPreprocessorDefinitions>
+  </PropertyGroup>
+
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories>$(CrtSysRoot)include;$(CrtSysRoot)include\.internal\msvc\$(VCToolsVersion);$(CrtSysRoot)include\.internal\msvc\$(PlatformToolsetVersion);$(CrtSysRoot)include\.internal\msvc\$(VCToolsVersion)\stl;$(CrtSysRoot)include\.internal\msvc\$(PlatformToolsetVersion)\stl;$(CrtSysRoot)include\.internal\msvc\143;$(CrtSysRoot)include\.internal\msvc\143\stl;$(CrtSysRoot)include\.internal\msvc\142;$(CrtSysRoot)include\.internal\msvc\142\stl;$(CrtSysRoot)include\.internal\msvc\141;$(CrtSysRoot)include\.internal\msvc\141\stl;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles>$(CrtSysRoot)include\.internal\adjust_link_order;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+      <PreprocessorDefinitions>$(CrtSysPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions>/Zc:threadSafeInit- %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+</Project>

--- a/nuget/build/native/crtsys.targets
+++ b/nuget/build/native/crtsys.targets
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Target Name="CrtSysValidateNativePackage" BeforeTargets="PrepareForBuild">
+    <Error
+      Condition="'$(CrtSysUseNtlMain)' != 'true'"
+      Text="The prebuilt crtsys NuGet package currently supports the ntl::main entry point flow only. Leave CrtSysUseNtlMain set to true." />
+    <Error
+      Condition="'$(CrtSysLibPlatform)' != 'x64' and '$(CrtSysLibPlatform)' != 'ARM64'"
+      Text="crtsys NuGet package contains prebuilt libraries for x64 and ARM64 only. Current platform is '$(Platform)'." />
+    <Error
+      Condition="!Exists('$(CrtSysLibDir)crtsys.lib')"
+      Text="crtsys.lib was not found under '$(CrtSysLibDir)'." />
+    <Error
+      Condition="!Exists('$(CrtSysLibDir)Ldk.lib')"
+      Text="Ldk.lib was not found under '$(CrtSysLibDir)'." />
+  </Target>
+
+  <ItemDefinitionGroup>
+    <Link>
+      <AdditionalLibraryDirectories>$(CrtSysLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies Condition="'$(CrtSysLibPlatform)' == 'x64'">crtsys.lib;Ldk.lib;libcntpr.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies Condition="'$(CrtSysLibPlatform)' != 'x64'">crtsys.lib;Ldk.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <EntryPointSymbol Condition="'$(CrtSysUseNtlMain)' == 'true'">CrtSysDriverEntry</EntryPointSymbol>
+      <AdditionalOptions Condition="'$(CrtSysLibPlatform)' == 'x64'">/FORCE:MULTIPLE %(AdditionalOptions)</AdditionalOptions>
+    </Link>
+  </ItemDefinitionGroup>
+</Project>

--- a/nuget/crtsys.nuspec
+++ b/nuget/crtsys.nuspec
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
+  <metadata>
+    <id>crtsys</id>
+    <version>0.0.0</version>
+    <authors>ntoskrnl7</authors>
+    <title>crtsys</title>
+    <description>C/C++ runtime support for Windows kernel-mode drivers.</description>
+    <projectUrl>https://github.com/ntoskrnl7/crtsys</projectUrl>
+    <repository type="git" url="https://github.com/ntoskrnl7/crtsys" />
+    <license type="file">LICENSE</license>
+    <readme>README.md</readme>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <tags>windows kernel driver wdk native cpp crt stl cmake</tags>
+  </metadata>
+  <files>
+    <file src="..\README.md" target="README.md" />
+    <file src="..\LICENSE" target="LICENSE" />
+    <file src="..\docs\**\*" target="docs" />
+    <file src="..\include\**\*" target="include" />
+    <file src="..\artifacts\nuget-staging\lib\native\**\*" target="lib\native" />
+
+    <file src="build\native\crtsys.props" target="build\native" />
+    <file src="build\native\crtsys.targets" target="build\native" />
+  </files>
+</package>

--- a/scripts/nuget/Build-CrtSysNuGetLibs.ps1
+++ b/scripts/nuget/Build-CrtSysNuGetLibs.ps1
@@ -1,0 +1,78 @@
+param(
+  [ValidateSet('x64', 'ARM64')]
+  [string[]] $Architecture = @('x64', 'ARM64'),
+
+  [ValidateSet('Release')]
+  [string] $Configuration = 'Release',
+
+  [string] $WindowsSdkVersion = '10.0.22621.0',
+
+  [string] $OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+  $OutputDirectory = Join-Path $repoRoot 'artifacts\nuget-staging'
+}
+
+$platformByArchitecture = @{
+  x64 = 'x64'
+  ARM64 = 'ARM64'
+}
+
+foreach ($arch in $Architecture) {
+  $platform = $platformByArchitecture[$arch]
+  $buildDir = Join-Path $repoRoot "artifacts\build\crtsys_$arch"
+  $libOutputDir = Join-Path $OutputDirectory "lib\native\$arch\$Configuration"
+
+  New-Item -ItemType Directory -Force -Path $buildDir | Out-Null
+  New-Item -ItemType Directory -Force -Path $libOutputDir | Out-Null
+
+  $configureArgs = @(
+    '-S', $repoRoot,
+    '-B', $buildDir,
+    '-G', 'Visual Studio 17 2022',
+    '-A', $platform,
+    '-T', 'host=x64',
+    "-DCMAKE_SYSTEM_VERSION=$WindowsSdkVersion",
+    "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=$WindowsSdkVersion",
+    '-DCMAKE_CXX_FLAGS=/MP',
+    '-DCRTSYS_NTL_MAIN=ON'
+  )
+
+  Write-Host "Configuring crtsys $arch $Configuration with Windows SDK $WindowsSdkVersion"
+  & cmake @configureArgs
+  if ($LASTEXITCODE -ne 0) {
+    throw "CMake configure failed with exit code $LASTEXITCODE."
+  }
+
+  Write-Host "Building crtsys $arch $Configuration"
+  & cmake --build $buildDir --config $Configuration --target crtsys --parallel
+  if ($LASTEXITCODE -ne 0) {
+    throw "CMake build failed with exit code $LASTEXITCODE."
+  }
+
+  $crtsysLib = Join-Path $repoRoot "lib\$arch\crtsys.lib"
+  if (-not (Test-Path $crtsysLib)) {
+    throw "crtsys.lib was not found: $crtsysLib"
+  }
+
+  $ldkCandidates = @(Get-ChildItem -Path $buildDir -Filter 'Ldk.lib' -Recurse -File | Sort-Object FullName)
+  if ($ldkCandidates.Count -eq 0) {
+    throw "Ldk.lib was not found under $buildDir"
+  }
+
+  Copy-Item -Path $crtsysLib -Destination (Join-Path $libOutputDir 'crtsys.lib') -Force
+  Copy-Item -Path $ldkCandidates[0].FullName -Destination (Join-Path $libOutputDir 'Ldk.lib') -Force
+
+  $pdbCandidates = Get-ChildItem -Path $buildDir -Filter '*.pdb' -Recurse -File |
+    Where-Object { $_.Name -in @('crtsys.pdb', 'Ldk.pdb') }
+  foreach ($pdb in $pdbCandidates) {
+    Copy-Item -Path $pdb.FullName -Destination (Join-Path $libOutputDir $pdb.Name) -Force
+  }
+
+  Write-Host "Staged crtsys libraries in $libOutputDir"
+}

--- a/scripts/nuget/Get-CrtSysVersion.ps1
+++ b/scripts/nuget/Get-CrtSysVersion.ps1
@@ -1,0 +1,26 @@
+param(
+  [string] $VersionHeader
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($VersionHeader)) {
+  $VersionHeader = Join-Path $repoRoot 'include\.internal\version'
+}
+
+if (-not (Test-Path $VersionHeader)) {
+  throw "Version header was not found: $VersionHeader"
+}
+
+$content = Get-Content -Raw $VersionHeader
+$major = [regex]::Match($content, '#define\s+CRTSYS_VERSION_MAJOR\s+(\d+)')
+$minor = [regex]::Match($content, '#define\s+CRTSYS_VERSION_MINOR\s+(\d+)')
+$patch = [regex]::Match($content, '#define\s+CRTSYS_VERSION_PATCH\s+(\d+)')
+
+if (-not ($major.Success -and $minor.Success -and $patch.Success)) {
+  throw "Could not parse CRTSYS_VERSION_MAJOR/MINOR/PATCH from $VersionHeader"
+}
+
+"$($major.Groups[1].Value).$($minor.Groups[1].Value).$($patch.Groups[1].Value)"

--- a/scripts/nuget/Pack-CrtSysNuGet.ps1
+++ b/scripts/nuget/Pack-CrtSysNuGet.ps1
@@ -1,0 +1,42 @@
+param(
+  [string] $Version,
+  [string] $OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+  $Version = & (Join-Path $PSScriptRoot 'Get-CrtSysVersion.ps1')
+}
+
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+  $OutputDirectory = Join-Path $repoRoot 'artifacts\nuget'
+}
+
+$manifest = Join-Path $repoRoot 'nuget\crtsys.nuspec'
+$stagingDirectory = Join-Path $repoRoot 'artifacts\nuget-staging'
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+
+foreach ($requiredPath in @(
+  'lib\native\x64\Release\crtsys.lib',
+  'lib\native\x64\Release\Ldk.lib',
+  'lib\native\ARM64\Release\crtsys.lib',
+  'lib\native\ARM64\Release\Ldk.lib'
+)) {
+  $fullPath = Join-Path $stagingDirectory $requiredPath
+  if (-not (Test-Path $fullPath)) {
+    throw "Required prebuilt library is missing: $fullPath. Run scripts\nuget\Build-CrtSysNuGetLibs.ps1 first."
+  }
+}
+
+Write-Host "Packing crtsys $Version to $OutputDirectory"
+& dotnet pack $manifest `
+  --output $OutputDirectory `
+  --version $Version
+
+if ($LASTEXITCODE -ne 0) {
+  throw "dotnet pack failed with exit code $LASTEXITCODE."
+}

--- a/scripts/nuget/Push-CrtSysNuGet.ps1
+++ b/scripts/nuget/Push-CrtSysNuGet.ps1
@@ -1,0 +1,42 @@
+param(
+  [string] $PackageDirectory,
+  [string] $Source = 'https://api.nuget.org/v3/index.json',
+  [string] $ApiKey = $env:NUGET_API_KEY,
+  [switch] $SkipDuplicate
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+if ([string]::IsNullOrWhiteSpace($PackageDirectory)) {
+  $PackageDirectory = Join-Path $repoRoot 'artifacts\nuget'
+}
+
+if ([string]::IsNullOrWhiteSpace($ApiKey)) {
+  throw 'NUGET_API_KEY is required to publish packages.'
+}
+
+$packages = @(Get-ChildItem -Path $PackageDirectory -Filter '*.nupkg' -File | Sort-Object FullName)
+if ($packages.Count -eq 0) {
+  throw "No .nupkg files were found in $PackageDirectory"
+}
+
+foreach ($package in $packages) {
+  $arguments = @(
+    'nuget', 'push', $package.FullName,
+    '--source', $Source,
+    '--api-key', $ApiKey,
+    '--no-symbols'
+  )
+
+  if ($SkipDuplicate) {
+    $arguments += '--skip-duplicate'
+  }
+
+  Write-Host "Publishing $($package.Name) to $Source"
+  & dotnet @arguments
+  if ($LASTEXITCODE -ne 0) {
+    throw "dotnet nuget push failed with exit code $LASTEXITCODE."
+  }
+}

--- a/src/custom/crt/misc.c
+++ b/src/custom/crt/misc.c
@@ -67,6 +67,9 @@ _Check_return_ _ACRTIMP int __cdecl _fdsign(_In_ float _X)
     return _FSIGN_C(_X);
 }
 
+#ifdef _MSC_VER
+#pragma function(llabs)
+#endif
 _Check_return_ _ACRTIMP long long __cdecl llabs(_In_ long long _X)
 {
     return _X < 0 ? -_X : _X;


### PR DESCRIPTION
## Summary

- Add a native NuGet package for Visual Studio/WDK consumers.
- Build and package prebuilt Release libraries for `x64` and `ARM64`:
  - `lib/native/x64/Release/crtsys.lib`
  - `lib/native/x64/Release/Ldk.lib`
  - `lib/native/ARM64/Release/crtsys.lib`
  - `lib/native/ARM64/Release/Ldk.lib`
- Add `build/native/crtsys.props` and `build/native/crtsys.targets` so installing the package automatically wires include paths, forced include, preprocessor definitions, library paths, linker inputs, and the `CrtSysDriverEntry` entry point.
- Add PowerShell helpers to resolve the package version, build/stage prebuilt libraries, pack `.nupkg`, and publish to nuget.org.
- Add a NuGet GitHub Actions workflow that packs on PR/push and publishes on `v*` tags or manual dispatch through NuGet Trusted Publishing/OIDC.
- Document the Visual Studio NuGet flow in English and Korean docs, including `Install-Package` usage and nuget.org Trusted Publishing policy values.

## Notes

This is intentionally a prebuilt native package now. The intended user flow is: create a Visual Studio WDK driver project, install `crtsys` from NuGet, include `ntl/driver`, and build. Users do not need to write a CMake project to consume the NuGet package.

The first package target is conservative: Release libraries only, `x64`/`ARM64` only, and the `ntl::main` entry-point flow only. Unsupported platforms/configurations fail early from the imported MSBuild targets instead of failing later at link time.

Publishing now uses NuGet Trusted Publishing instead of a long-lived `NUGET_API_KEY` repository secret. The nuget.org policy should use repository owner `ntoskrnl7`, repository `crtsys`, workflow file `nuget.yml`, and no environment restriction.

The pack workflow uses .NET 10 because direct `.nuspec` packing is available there and preserves this native package layout reliably.

## Validation

- `git diff --check`
- Parsed `.github/workflows/nuget.yml` with PyYAML
- Parsed NuGet manifest and native MSBuild files with Python XML parser
- GitHub Actions `CMake` matrix passed for app x86/x64/ARM64 and driver x64/ARM64 on commit `29ebc56`
- GitHub Actions `NuGet / Pack NuGet` passed on commit `29ebc56`
- GitHub Actions `NuGet / Publish NuGet` is correctly skipped on pull requests
- Downloaded the generated `crtsys.0.1.10.nupkg` artifact from run `27530864945` and verified key paths:
  - `build/native/crtsys.props`
  - `build/native/crtsys.targets`
  - `include/.internal/adjust_link_order`
  - `include/ntl/driver`
  - `lib/native/x64/Release/crtsys.lib`
  - `lib/native/x64/Release/Ldk.lib`
  - `lib/native/ARM64/Release/crtsys.lib`
  - `lib/native/ARM64/Release/Ldk.lib`