### PR TITLE
[codex] fix NuGet trusted publishing user configuration

### DIFF
--- a/.github/workflows/nuget.yml
+++ b/.github/workflows/nuget.yml
@@ -120,11 +120,18 @@ jobs:
           name: crtsys-nuget-${{ needs.pack.outputs.package_version }}
           path: artifacts/nuget
 
+      - name: Validate NuGet trusted publishing user
+        shell: pwsh
+        run: |
+          if ([string]::IsNullOrWhiteSpace('${{ vars.NUGET_TRUSTED_PUBLISHING_USER }}')) {
+            throw 'Repository variable NUGET_TRUSTED_PUBLISHING_USER is required for NuGet Trusted Publishing.'
+          }
+
       - name: NuGet login
         uses: NuGet/login@v1
         id: nuget-login
         with:
-          user: ntoskrnl7
+          user: ${{ vars.NUGET_TRUSTED_PUBLISHING_USER }}
 
       - name: Publish to nuget.org
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -198,8 +198,10 @@ pushes. A tag such as `v0.1.10` publishes to nuget.org through NuGet Trusted
 Publishing when the tag version matches `include/.internal/version`.
 
 For GitHub Actions publishing, create a nuget.org Trusted Publishing policy
-with repository owner `ntoskrnl7`, repository `crtsys`, workflow file
-`nuget.yml`, and no environment restriction.
+with the package owner shown by nuget.org, repository owner `ntoskrnl7`,
+repository `crtsys`, workflow file `nuget.yml`, and no environment
+restriction. Set the GitHub Actions repository variable
+`NUGET_TRUSTED_PUBLISHING_USER` to the nuget.org user that created the policy.
 
 ## Building This Repository
 

--- a/docs/ko-kr.md
+++ b/docs/ko-kr.md
@@ -199,8 +199,11 @@ GitHub Actions도 pull request와 push에서 prebuilt library와 패키지를
 nuget.org로 publish합니다.
 
 GitHub Actions publish를 사용하려면 nuget.org Trusted Publishing policy를
-repository owner `ntoskrnl7`, repository `crtsys`, workflow file `nuget.yml`,
-environment 제한 없음으로 생성합니다.
+nuget.org에 표시되는 package owner, repository owner `ntoskrnl7`,
+repository `crtsys`, workflow file `nuget.yml`, environment 제한 없음으로
+생성합니다. GitHub Actions repository variable
+`NUGET_TRUSTED_PUBLISHING_USER`에는 policy를 생성한 nuget.org 사용자를
+설정합니다.
 
 ## 이 저장소 빌드
 


### PR DESCRIPTION
## Summary

- Remove the hardcoded NuGet.org user from the workflow and documentation.
- Read the Trusted Publishing login user from the repository variable `NUGET_TRUSTED_PUBLISHING_USER`.
- Add a publish-time validation step so missing repository variable configuration fails with a clear message.
- Keep README and Korean docs generic: the package owner is the value shown by nuget.org, and the login user is the policy creator.

## Why

NuGet Trusted Publishing's `NuGet/login@v1` `user` input must match the NuGet.org user that created the policy. That value can differ from the GitHub repository owner, so it should be configured as repository metadata rather than hardcoded in source documentation.

## Validation

- `git diff --check`
- Parsed `.github/workflows/nuget.yml` with PyYAML
- Verified no personal NuGet.org username remains in the workflow/docs with `rg`