### PR TITLE
fix spin lock IRQL release handling

### DIFF
--- a/include/ntl/spin_lock
+++ b/include/ntl/spin_lock
@@ -35,14 +35,36 @@ public:
   spin_lock &operator=(const spin_lock &) = delete;
 
   _NODISCARD bool try_lock() {
-    return KeTryToAcquireSpinLockAtDpcLevel(lock_) == TRUE;
+    KIRQL old_irql = KeRaiseIrqlToDpcLevel();
+    if (KeTryToAcquireSpinLockAtDpcLevel(lock_) == TRUE) {
+      old_irql_ = old_irql;
+      acquired_at_dpc_level_ = false;
+      return true;
+    }
+    KeLowerIrql(old_irql);
+    return false;
   }
 
-  void lock() { KeAcquireSpinLock(lock_, &old_irql_); }
-  void unlock() { KeReleaseSpinLock(lock_, old_irql_); }
+  void lock() {
+    KeAcquireSpinLock(lock_, &old_irql_);
+    acquired_at_dpc_level_ = false;
+  }
+  void unlock() {
+    if (acquired_at_dpc_level_) {
+      unlock_from_dpc_level();
+      return;
+    }
+    KeReleaseSpinLock(lock_, old_irql_);
+  }
 
-  void lock_at_dpc_level() { KeAcquireSpinLockAtDpcLevel(lock_); }
-  void unlock_from_dpc_level() { KeReleaseSpinLockFromDpcLevel(lock_); }
+  void lock_at_dpc_level() {
+    KeAcquireSpinLockAtDpcLevel(lock_);
+    acquired_at_dpc_level_ = true;
+  }
+  void unlock_from_dpc_level() {
+    KeReleaseSpinLockFromDpcLevel(lock_);
+    acquired_at_dpc_level_ = false;
+  }
 
   bool test() { return KeTestSpinLock(lock_); }
 
@@ -51,8 +73,9 @@ public:
   _NODISCARD native_handle_type native_handle() { return lock_; }
 
 private:
-  PKSPIN_LOCK lock_;
-  KIRQL old_irql_;
+  PKSPIN_LOCK lock_ = nullptr;
+  KIRQL old_irql_ = PASSIVE_LEVEL;
+  bool acquired_at_dpc_level_ = false;
 };
 
 struct at_dpc_level_lock_t {
@@ -116,7 +139,7 @@ public:
 
   ~unique_lock() noexcept {
     if (owns_)
-      lockable_->unlock_from_dpc_level();
+      lockable_->unlock();
   }
 
   unique_lock(const unique_lock &) = delete;

--- a/test/driver/src/ntl.cpp
+++ b/test/driver/src/ntl.cpp
@@ -1,6 +1,7 @@
 #include <ntl/expand_stack>
 
 #include <string>
+#include <utility>
 
 bool ntl_expand_stack_test() {
   long result = 0;
@@ -80,6 +81,8 @@ bool ntl_irql_test() {
 bool ntl_spin_lock_test() {
   ntl::spin_lock lock;
   ntl::spin_lock lock2;
+  ntl::spin_lock lock3;
+  auto old_irql = ntl::current_irql();
 
   if (!lock.test())
     return false;
@@ -87,15 +90,53 @@ bool ntl_spin_lock_test() {
   if (!lock2.test())
     return false;
 
-  std::unique_lock<ntl::spin_lock> lk(lock);
-  if (!lk.owns_lock())
+  {
+    ntl::unique_lock<ntl::spin_lock> lk(lock);
+    if (!lk.owns_lock())
+      return false;
+    if (lock.test())
+      return false;
+    if (ntl::current_irql() != ntl::irql::dispatch)
+      return false;
+  }
+  if (!lock.test())
     return false;
-
-  std::unique_lock<ntl::spin_lock> lk2(lock, std::try_to_lock);
-  if (lk2.owns_lock())
+  if (ntl::current_irql() != old_irql)
     return false;
 
   {
+    std::unique_lock<ntl::spin_lock> lk(lock);
+    if (!lk.owns_lock())
+      return false;
+
+    std::unique_lock<ntl::spin_lock> lk2(lock, std::try_to_lock);
+    if (lk2.owns_lock())
+      return false;
+  }
+  if (!lock.test())
+    return false;
+  if (ntl::current_irql() != old_irql)
+    return false;
+
+  {
+    std::unique_lock<ntl::spin_lock> lk(lock, std::try_to_lock);
+    if (!lk.owns_lock())
+      return false;
+    if (lock.test())
+      return false;
+    if (ntl::current_irql() != ntl::irql::dispatch)
+      return false;
+  }
+  if (!lock.test())
+    return false;
+  if (ntl::current_irql() != old_irql)
+    return false;
+
+  {
+    auto raised_irql = ntl::raise_irql_to_dpc_level();
+    if (old_irql != raised_irql.old())
+      return false;
+
     ntl::unique_lock<ntl::spin_lock> nlk(lock2, ntl::at_dpc_level_lock);
     if (!nlk.owns_lock())
       return false;
@@ -108,8 +149,31 @@ bool ntl_spin_lock_test() {
   }
   if (!lock2.test())
     return false;
+  if (ntl::current_irql() != old_irql)
+    return false;
 
-  return KeTestSpinLock(lock.native_handle()) == FALSE;
+  {
+    auto raised_irql = ntl::raise_irql_to_dpc_level();
+    if (old_irql != raised_irql.old())
+      return false;
+
+    ntl::unique_lock<ntl::spin_lock> nlk(lock2, ntl::at_dpc_level_lock);
+    ntl::unique_lock<ntl::spin_lock> nlk2(lock3, ntl::at_dpc_level_lock);
+    nlk = std::move(nlk2);
+
+    if (!lock2.test())
+      return false;
+    if (lock3.test())
+      return false;
+    if (!nlk.owns_lock())
+      return false;
+    if (nlk2.owns_lock())
+      return false;
+  }
+  if (!lock3.test())
+    return false;
+
+  return ntl::current_irql() == old_irql;
 }
 
 #include <ntl/resource>
@@ -249,23 +313,64 @@ TEST(ntl_test, ntl_irql_test) {
 TEST(ntl_test, ntl_spin_lock_test) {
   ntl::spin_lock lock;
   ntl::spin_lock lock2;
+  ntl::spin_lock lock3;
+  auto old_irql = ntl::current_irql();
+
   {
     EXPECT_TRUE(lock.test());
 
-    std::unique_lock lk(lock);
+    ntl::unique_lock<ntl::spin_lock> lk(lock);
     EXPECT_FALSE(lock.test());
     EXPECT_TRUE(lk.owns_lock());
+    EXPECT_EQ(ntl::current_irql(), ntl::irql::dispatch);
+  }
+  EXPECT_TRUE(lock.test());
+  EXPECT_EQ(ntl::current_irql(), old_irql);
 
+  {
+    std::unique_lock lk(lock);
     std::unique_lock lk2(lock, std::try_to_lock);
     EXPECT_FALSE(lock.test());
     EXPECT_FALSE(lk2.owns_lock());
+  }
+  EXPECT_TRUE(lock.test());
+  EXPECT_EQ(ntl::current_irql(), old_irql);
+
+  {
+    std::unique_lock lk(lock, std::try_to_lock);
+    EXPECT_FALSE(lock.test());
+    EXPECT_TRUE(lk.owns_lock());
+    EXPECT_EQ(ntl::current_irql(), ntl::irql::dispatch);
+  }
+  EXPECT_TRUE(lock.test());
+  EXPECT_EQ(ntl::current_irql(), old_irql);
+
+  {
+    auto raised_irql = ntl::raise_irql_to_dpc_level();
+    EXPECT_EQ(old_irql, raised_irql.old());
 
     ntl::unique_lock<ntl::spin_lock> lk3(lock2, ntl::at_dpc_level_lock);
     EXPECT_FALSE(lock2.test());
     EXPECT_TRUE(lk3.owns_lock());
   }
-  EXPECT_TRUE(lock.test());
+  EXPECT_TRUE(lock2.test());
+  EXPECT_EQ(ntl::current_irql(), old_irql);
+
+  {
+    auto raised_irql = ntl::raise_irql_to_dpc_level();
+    EXPECT_EQ(old_irql, raised_irql.old());
+
+    ntl::unique_lock<ntl::spin_lock> lk3(lock2, ntl::at_dpc_level_lock);
+    ntl::unique_lock<ntl::spin_lock> lk4(lock3, ntl::at_dpc_level_lock);
+    lk3 = std::move(lk4);
+    EXPECT_TRUE(lock2.test());
+    EXPECT_FALSE(lock3.test());
+    EXPECT_TRUE(lk3.owns_lock());
+    EXPECT_FALSE(lk4.owns_lock());
+  }
+  EXPECT_TRUE(lock3.test());
   EXPECT_TRUE(KeTestSpinLock(lock.native_handle()));
+  EXPECT_EQ(ntl::current_irql(), old_irql);
 }
 
 TEST(ntl_test, ntl_resource_test) {


### PR DESCRIPTION
## Summary

Fix `ntl::spin_lock` release handling so RAII wrappers release through the correct kernel spin-lock path for both normal and at-DPC acquisitions.

## Root Cause

`ntl::unique_lock<ntl::spin_lock>` tracked custom ownership with a single `owns_` flag, but its destructor always called `unlock_from_dpc_level()`. That is correct for `at_dpc_level_lock`, but wrong for the normal constructor path because `KeAcquireSpinLock` must be paired with `KeReleaseSpinLock(..., old_irql)` to restore the caller's previous IRQL.

`try_lock()` also used `KeTryToAcquireSpinLockAtDpcLevel()` directly, which made `std::try_to_lock` awkward outside an already-DPC context and left the release path dependent on stale IRQL state.

## Changes

- Track whether the current acquisition came from `lock_at_dpc_level()`.
- Make `unlock()` dispatch to `KeReleaseSpinLockFromDpcLevel()` only for at-DPC acquisitions.
- Make `try_lock()` raise to DPC, try the lock, and restore IRQL on failure.
- Make `ntl::unique_lock<ntl::spin_lock>` call `unlock()` in its destructor.
- Expand spin-lock tests to assert IRQL restoration for normal, try-lock, at-DPC, and move-assignment paths.

## Validation

- `git diff --check HEAD~1 HEAD`

The actual Windows driver build/test should run in GitHub Actions because this Linux workspace cannot execute the WDK-based driver test locally.