### PR TITLE
[codex] fix NuGet consumer dependency install isolation

### DIFF
--- a/scripts/nuget/Test-CrtSysNuGetPackage.ps1
+++ b/scripts/nuget/Test-CrtSysNuGetPackage.ps1
@@ -143,6 +143,7 @@ if ($isDriverConsumer) {
 }
 
 $packagesDirectory = Join-Path $testProjectDirectory 'packages'
+$nlohmannJsonPackageRoot = $null
 & $nuget.Source install crtsys `
   -Version $Version `
   -Source $PackageDirectory `
@@ -179,10 +180,11 @@ foreach ($requiredPath in $requiredPackagePaths) {
 }
 
 if ($isDriverConsumer) {
+  $externalPackagesDirectory = Join-Path $testProjectDirectory 'external-packages'
   & $nuget.Source install nlohmann.json `
     -Version 3.12.0 `
     -Source https://api.nuget.org/v3/index.json `
-    -OutputDirectory $packagesDirectory `
+    -OutputDirectory $externalPackagesDirectory `
     -ExcludeVersion `
     -NonInteractive `
     -Verbosity detailed
@@ -191,7 +193,7 @@ if ($isDriverConsumer) {
     throw "nlohmann.json NuGet install failed with exit code $LASTEXITCODE."
   }
 
-  $nlohmannJsonPackageRoot = Join-Path $packagesDirectory 'nlohmann.json'
+  $nlohmannJsonPackageRoot = Join-Path $externalPackagesDirectory 'nlohmann.json'
   foreach ($requiredPath in @(
     'build\native\nlohmann.json.targets',
     'build\native\include\nlohmann\json.hpp'
@@ -200,6 +202,11 @@ if ($isDriverConsumer) {
     if (-not (Test-Path $fullPath)) {
       throw "Installed nlohmann.json package is missing expected file: $fullPath"
     }
+  }
+
+  $nlohmannJsonPackageRoot = (Resolve-Path $nlohmannJsonPackageRoot).Path
+  if (-not $nlohmannJsonPackageRoot.EndsWith('\')) {
+    $nlohmannJsonPackageRoot += '\'
   }
 }
 
@@ -223,6 +230,7 @@ $msbuildArguments = @(
 if ($isDriverConsumer) {
   $msbuildArguments += "/p:WindowsTargetPlatformVersion=$WdkVersion"
   $msbuildArguments += '/p:SignMode=Off'
+  $msbuildArguments += "/p:NlohmannJsonPackageRoot=$nlohmannJsonPackageRoot"
 } else {
   $msbuildArguments += "/p:WindowsTargetPlatformVersion=$WindowsSdkVersion"
 }

--- a/test/nuget/crtsys_nuget_test.vcxproj
+++ b/test/nuget/crtsys_nuget_test.vcxproj
@@ -46,7 +46,7 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
     <CrtSysPackageRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
-    <NlohmannJsonPackageRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'nlohmann.json'))</NlohmannJsonPackageRoot>
+    <NlohmannJsonPackageRoot Condition="'$(NlohmannJsonPackageRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'nlohmann.json'))</NlohmannJsonPackageRoot>
     <TargetName>crtsys_nuget_test</TargetName>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets">


### PR DESCRIPTION
## Summary
- install the external `nlohmann.json` test dependency outside the local `crtsys` package restore folder
- allow the NuGet driver smoke project to receive `NlohmannJsonPackageRoot` from MSBuild

## Why
The 0.1.12 publish run failed before publishing because the driver consumer smoke test installed local `crtsys` first, then installed `nlohmann.json` from nuget.org into the same `packages` directory. NuGet tried to resolve the already-installed local `crtsys 0.1.12` against nuget.org, where that version does not exist yet.

## Validation
- `git diff --check`
- XML parse of `test/nuget/crtsys_nuget_test.vcxproj`