### PR TITLE
Fix package workflow dispatch gates and release job checkout

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -268,7 +268,7 @@ jobs:
   publish:
     name: Publish NuGet
     needs: [pack, test-package-driver, test-package-app]
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.publish)
+    if: ${{ (github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.publish) }}
     runs-on: windows-2022
     permissions:
       contents: read
@@ -308,12 +308,14 @@ jobs:
   github-release:
     name: Upload GitHub Release Assets
     needs: [pack, test-package-driver, test-package-app, test-release-native-cmake]
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.github_release)
+    if: ${{ (github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.github_release) }}
     runs-on: windows-2022
     permissions:
       contents: write
 
     steps:
+      - uses: actions/checkout@v5
+
       - uses: actions/download-artifact@v7
         with:
           name: crtsys-release-assets-${{ needs.pack.outputs.package_version }}


### PR DESCRIPTION
- Gate publish/github-release jobs so manual workflow_dispatch respects publish/github_release inputs.
- Keep tag-trigger behavior as before for push/tag events.
- Add checkout in github-release job so gh release create doesn't fail due missing .git context.