### PR TITLE
chore: align NuGet/Release naming and docs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -237,8 +237,8 @@ jobs:
           -Configuration '${{ matrix.config }}'
           -WindowsSdkVersion '10.0.22621.0'
 
-  test-release-native-cmake:
-    name: Test release native CMake asset ${{ matrix.arch }} ${{ matrix.config }}
+  test-release-prebuilt-cmake:
+    name: Test release prebuilt CMake asset ${{ matrix.arch }} ${{ matrix.config }}
     needs: pack
     runs-on: windows-2022
     strategy:
@@ -255,7 +255,7 @@ jobs:
           name: crtsys-release-assets-${{ needs.pack.outputs.package_version }}
           path: artifacts/release
 
-      - name: Build native release CMake consumer test
+      - name: Build prebuilt release CMake consumer test
         shell: pwsh
         run: >
           ./scripts/nuget/Test-CrtSysReleaseAssets.ps1
@@ -307,7 +307,7 @@ jobs:
 
   github-release:
     name: Upload GitHub Release Assets
-    needs: [pack, test-package-driver, test-package-app, test-release-native-cmake]
+    needs: [pack, test-package-driver, test-package-app, test-release-prebuilt-cmake]
     if: ${{ (github.event_name != 'workflow_dispatch' && startsWith(github.ref, 'refs/tags/v')) || (github.event_name == 'workflow_dispatch' && inputs.github_release) }}
     runs-on: windows-2022
     permissions:
@@ -349,7 +349,7 @@ jobs:
               "crtsys $version release assets."
               ""
               "- crtsys.$version.nupkg: offline NuGet package"
-              "- crtsys-$version-native.zip: headers, docs, CMake helpers, native MSBuild imports, and prebuilt x64/ARM64 Debug/Release libraries"
+              "- crtsys-$version-prebuilt.zip: headers, docs, CMake helpers, native MSBuild imports, and prebuilt x64/ARM64 Debug/Release libraries"
               "- crtsys-$version-SHA256SUMS.txt: SHA-256 checksums"
             ) -join [Environment]::NewLine
             & gh release create $tagName @assets --repo $repo --target '${{ github.sha }}' --title "crtsys $version" --notes $notes

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ project(my_driver LANGUAGES C CXX)
 include(cmake/CPM.cmake)
 
 set(CRTSYS_NTL_MAIN ON)
-CPMAddPackage("gh:ntoskrnl7/crtsys@0.1.10")
+CPMAddPackage("gh:ntoskrnl7/crtsys@<version>")
 include(${crtsys_SOURCE_DIR}/cmake/CrtSys.cmake)
 
 crtsys_add_driver(my_driver src/main.cpp)
@@ -163,121 +163,45 @@ cmake --build build_x64 --config Debug
 
 ## NuGet Package
 
-`crtsys` can be distributed as a native NuGet package for Visual Studio/MSBuild
-projects. The package includes public NTL headers, internal compatibility
-headers, native MSBuild imports, and prebuilt `crtsys.lib`/`Ldk.lib` driver
-binaries.
+`crtsys` NuGet distribution is:
 
-The package has two consumer modes:
+- `crtsys.<version>.nupkg`: install from Visual Studio/MSBuild.
 
-- App mode: normal Visual C++ application projects get the public NTL headers
-  and C++ compatibility options only. No driver libraries, forced include, or
-  driver entry point are added.
-- Driver mode: WDK driver projects get the CMake-equivalent driver settings:
-  `crtsys` include paths, MSVC/STL compatibility headers before WDK `km\crt`,
-  forced include setup, preprocessor definitions, `crtsys.lib`, `Ldk.lib`,
-  `libcntpr.lib`, `/FORCE:MULTIPLE`, and the `CrtSysDriverEntry` entry point
-  for the default `ntl::main` flow.
-
-Driver mode is enabled automatically when MSBuild sees a driver project
-(`ConfigurationType=Driver` or `DriverType` is set). It can also be forced with
-`CrtSysUseDriverSupport=true`. The package does not turn a normal C++ project,
-console application, static library, or CMake project into a WDK driver project,
-and it does not install or replace the WDK toolset.
-
-Driver builds may emit `LNK4088` because `crtsys` intentionally uses
-`/FORCE:MULTIPLE` for known duplicate CRT/runtime symbols between `libcntpr`,
-`Ldk`, `ntoskrnl`, and the runtime glue. Treat that as an expected build
-warning only when the remaining link output contains no unresolved symbols and
-the duplicate symbols are in the known runtime boundary. Final drivers still
-need load, verifier, signing, and target-OS validation.
-
-The current binary package targets:
-
-- Visual Studio 2022
-- Windows SDK/WDK `10.0.22621.0`
-- App header builds on `x86`, `x64`, and `ARM64`
-- Driver library builds on `x64` and `ARM64`
-- Debug/Release `crtsys.lib`, `Ldk.lib`, and WDK `libcntpr.lib`
-
-Install it from Visual Studio's **Manage NuGet Packages** UI. In the Package
-Manager Console, select your app or driver project as the default project and
-run:
+Install from VS/MSBuild:
 
 ```powershell
 Install-Package crtsys
 ```
 
-For an app project, include headers such as `ntl/rpc/client` directly.
+## GitHub Release Prebuilt Bundle
 
-For a driver project, define `ntl::main`:
+GitHub Release publishes these offline-only assets:
 
-```cpp
-#include <ntl/driver>
+- `crtsys-<version>-prebuilt.zip`: headers, docs, CMake helpers,
+  and prebuilt `x64/ARM64` `Debug`/`Release` libraries.
+- `crtsys-<version>-SHA256SUMS.txt`
 
-ntl::status ntl::main(ntl::driver& driver,
-                      const std::wstring& registry_path) {
-  driver.on_unload([]() {});
-  return ntl::status::ok();
-}
-```
-
-For native MSBuild consumers, the package also exposes `$(CrtSysRoot)`.
-See [NTL usage examples](./docs/usage-examples.md) for the app/driver RPC and
-raw IOCTL skeletons.
-
-Pack locally:
+Use the prebuilt bundle for WDK CMake/offline bootstrap:
 
 ```powershell
-.\scripts\nuget\Build-CrtSysNuGetLibs.ps1
-.\scripts\nuget\Pack-CrtSysNuGet.ps1
+Expand-Archive .\crtsys-<version>-prebuilt.zip .
 ```
-
-Publish with an API key in the environment:
-
-```powershell
-$env:NUGET_API_KEY = '<nuget-api-key>'
-.\scripts\nuget\Push-CrtSysNuGet.ps1 -SkipDuplicate
-```
-
-GitHub Actions builds the prebuilt libraries and package on pull requests and
-pushes. A tag such as `v0.1.12` publishes to nuget.org through NuGet Trusted
-Publishing when the tag version matches `include/.internal/version`.
-The same tag build also creates GitHub Release assets. Manual workflow runs can
-set `github_release=true` to create or update the matching GitHub Release
-without pushing a tag.
-
-Release assets include:
-
-- `crtsys.<version>.nupkg` for offline NuGet installation.
-- `crtsys-<version>-native.zip` with headers, docs, CMake helpers, native
-  MSBuild imports, and prebuilt x64/ARM64 Debug/Release driver libraries.
-- `crtsys-<version>-SHA256SUMS.txt` for asset checksums.
-
-The native zip includes `cmake/CrtSys.cmake`, and the same `crtsys_add_driver`
-API can consume the prebuilt driver libraries when it is included from the
-unpacked bundle. A WDK CMake project can unpack the zip and use:
 
 ```cmake
 include(path/to/crtsys-<version>/cmake/CrtSys.cmake)
 crtsys_add_driver(my_driver src/main.cpp)
 ```
 
-For GitHub Actions publishing, create a nuget.org Trusted Publishing policy
-with the package owner shown by nuget.org, repository owner `ntoskrnl7`,
-repository `crtsys`, workflow file `package.yml`, and no environment
-restriction. Set the GitHub Actions repository variable
-`NUGET_TRUSTED_PUBLISHING_USER` to the nuget.org user that created the policy.
+For full packaging and publishing command details, see `nuget/README.md`.
 
-To prepare a release without manually editing `include/.internal/version`, run
-the release helper from an up-to-date `main` branch:
+To publish a new version from `main`:
 
 ```powershell
-.\scripts\release\Prepare-CrtSysRelease.ps1 -Version 0.1.13 -Push
+.\scripts\release\Prepare-CrtSysRelease.ps1 -Version <version> -Push
 ```
 
 The helper updates `include/.internal/version`, commits the version bump,
-creates the matching `v0.1.13` tag, and pushes both the commit and tag. The tag
+creates the matching `v<version>` tag, and pushes both the commit and tag. The tag
 push starts the `Package` workflow.
 
 The same flow is also available from the GitHub UI: open **Actions**,

--- a/docs/ko-kr.md
+++ b/docs/ko-kr.md
@@ -125,7 +125,7 @@ project(my_driver LANGUAGES C CXX)
 include(cmake/CPM.cmake)
 
 set(CRTSYS_NTL_MAIN ON)
-CPMAddPackage("gh:ntoskrnl7/crtsys@0.1.10")
+CPMAddPackage("gh:ntoskrnl7/crtsys@<version>")
 include(${crtsys_SOURCE_DIR}/cmake/CrtSys.cmake)
 
 crtsys_add_driver(my_driver src/main.cpp)
@@ -163,131 +163,41 @@ cmake --build build_x64 --config Debug
 
 ## NuGet 패키지
 
-`crtsys`는 Visual Studio/MSBuild 프로젝트에서 사용할 수 있는 native NuGet
-패키지로 배포할 수 있습니다. 패키지에는 공개 NTL 헤더, 내부 호환성 헤더,
-native MSBuild import 파일, 미리 빌드된 driver용 `crtsys.lib`와
-`Ldk.lib`가 포함됩니다.
+`crtsys`의 NuGet 배포는 다음 하나뿐입니다.
 
-패키지는 두 가지 소비 모드를 가집니다.
+- `crtsys.<version>.nupkg`: Visual Studio/MSBuild 프로젝트용
 
-- App mode: 일반 Visual C++ application 프로젝트에서는 공개 NTL 헤더와 C++
-  호환성 옵션만 추가합니다. driver library, forced include, driver entry
-  point는 추가하지 않습니다.
-- Driver mode: WDK driver 프로젝트에서는 CMake의 driver 설정과 같은 방향으로
-  `crtsys` include 경로, WDK `km\crt`보다 앞서는 MSVC/STL 호환성 헤더,
-  forced include, preprocessor 정의, `crtsys.lib`, `Ldk.lib`,
-  `libcntpr.lib`, `/FORCE:MULTIPLE`, 기본 `ntl::main` 흐름을 위한
-  `CrtSysDriverEntry` entry point를 설정합니다.
-
-Driver mode는 MSBuild가 driver 프로젝트를 감지할 때 자동으로 켜집니다
-(`ConfigurationType=Driver` 또는 `DriverType`이 설정된 경우). 필요하면
-`CrtSysUseDriverSupport=true`로 강제로 켤 수 있습니다. 이 패키지는 일반 C++
-프로젝트, console application, static library, CMake 프로젝트를 WDK driver
-프로젝트로 변환하지 않으며 WDK toolset을 설치하거나 대체하지 않습니다.
-
-driver build에서는 `LNK4088`이 보일 수 있습니다. `crtsys`는 `libcntpr`,
-`Ldk`, `ntoskrnl`, runtime glue 사이의 알려진 CRT/runtime symbol 중복을
-처리하기 위해 의도적으로 `/FORCE:MULTIPLE`을 사용합니다. 이 경고는 남은
-link output에 unresolved symbol이 없고, 중복 symbol이 알려진 runtime 경계
-안에 있을 때만 예상 가능한 build warning으로 보아야 합니다. 최종 드라이버는
-여전히 load, verifier, signing, 대상 OS 검증이 필요합니다.
-
-현재 binary 패키지 대상은 다음과 같습니다.
-
-- Visual Studio 2022
-- Windows SDK/WDK `10.0.22621.0`
-- App header build: `x86`, `x64`, `ARM64`
-- Driver library build: `x64`, `ARM64`
-- Debug/Release `crtsys.lib`, `Ldk.lib`, WDK `libcntpr.lib`
-
-Visual Studio의 **Manage NuGet Packages** UI에서 설치합니다. Package
-Manager Console을 사용할 때는 기본 프로젝트를 app 또는 driver 프로젝트로
-선택한 뒤 다음 명령을 실행합니다.
+MSBuild 설치:
 
 ```powershell
 Install-Package crtsys
 ```
 
-App 프로젝트에서는 `ntl/rpc/client` 같은 헤더를 바로 포함해서 사용합니다.
+## GitHub Release prebuilt 번들
 
-Driver 프로젝트에서는 `ntl::main`을 정의합니다.
+GitHub Release는 별도 오프라인 번들을 배포합니다.
 
-```cpp
-#include <ntl/driver>
+- `crtsys-<version>-prebuilt.zip`: 헤더, 문서, CMake 헬퍼,
+  x64/ARM64의 `Debug`/`Release` 사전 빌드 라이브러리.
+- `crtsys-<version>-SHA256SUMS.txt`
 
-ntl::status ntl::main(ntl::driver& driver,
-                      const std::wstring& registry_path) {
-  driver.on_unload([]() {});
-  return ntl::status::ok();
-}
-```
-
-native MSBuild 소비자를 위해 패키지는 `$(CrtSysRoot)` 속성도 제공합니다.
-app/driver RPC와 raw IOCTL 골격은 [NTL 사용 예제](./ko-kr-usage-examples.md)를
-참고하세요.
-
-로컬에서 패키지를 만들려면 다음 명령을 사용합니다.
+WDK CMake/오프라인 부트스트랩은 prebuilt 번들을 사용합니다.
 
 ```powershell
-.\scripts\nuget\Build-CrtSysNuGetLibs.ps1
-.\scripts\nuget\Pack-CrtSysNuGet.ps1
+Expand-Archive .\crtsys-<version>-prebuilt.zip .
+
 ```
-
-환경 변수에 API key가 있을 때 publish할 수 있습니다.
-
-```powershell
-$env:NUGET_API_KEY = '<nuget-api-key>'
-.\scripts\nuget\Push-CrtSysNuGet.ps1 -SkipDuplicate
-```
-
-GitHub Actions도 pull request와 push에서 prebuilt library와 패키지를
-생성합니다. `v0.1.12` 같은 태그를 push하면, 태그 버전이
-`include/.internal/version`과 일치할 때 NuGet Trusted Publishing을 통해
-nuget.org로 publish합니다.
-같은 태그 빌드는 GitHub Release asset도 생성합니다. 수동 workflow 실행에서
-`github_release=true`를 지정하면 태그를 새로 push하지 않고도 해당 버전의
-GitHub Release를 만들거나 갱신할 수 있습니다.
-
-Release asset에는 다음 파일이 포함됩니다.
-
-- 오프라인 NuGet 설치용 `crtsys.<version>.nupkg`.
-- 헤더, 문서, CMake helper, native MSBuild import, x64/ARM64 Debug/Release
-  driver library가 포함된 `crtsys-<version>-native.zip`.
-- asset 검증용 `crtsys-<version>-SHA256SUMS.txt`.
-
-native zip에는 `cmake/CrtSys.cmake`가 포함되며, 이 파일을 unpack된 bundle에서
-include하면 같은 `crtsys_add_driver` API가 prebuilt driver library를
-사용합니다. WDK CMake 프로젝트에서는 zip을 푼 뒤 다음처럼 사용할 수
-있습니다.
 
 ```cmake
+# 기존 드라이버 CMakeLists.txt
 include(path/to/crtsys-<version>/cmake/CrtSys.cmake)
 crtsys_add_driver(my_driver src/main.cpp)
 ```
 
-GitHub Actions publish를 사용하려면 nuget.org Trusted Publishing policy를
-nuget.org에 표시되는 package owner, repository owner `ntoskrnl7`,
-repository `crtsys`, workflow file `package.yml`, environment 제한 없음으로
-생성합니다. GitHub Actions repository variable
-`NUGET_TRUSTED_PUBLISHING_USER`에는 policy를 생성한 nuget.org 사용자를
-설정합니다.
+`prebuilt.zip`은 GitHub Release 전용 번들이며 NuGet 패키지가 아닙니다.
 
-`include/.internal/version`을 직접 수정하지 않고 release를 준비하려면 최신
-`main` branch에서 release helper를 실행합니다.
-
-```powershell
-.\scripts\release\Prepare-CrtSysRelease.ps1 -Version 0.1.13 -Push
-```
-
-이 helper는 `include/.internal/version`을 수정하고, version bump commit을
-만든 뒤, 대응되는 `v0.1.13` tag를 만들고 commit과 tag를 push합니다. tag
-push가 `Package` workflow를 시작합니다.
-
-같은 흐름은 GitHub UI에서도 사용할 수 있습니다. **Actions**에서
-**Release**를 선택하고 **Run workflow**를 눌러 release version을 입력하면
-workflow가 version bump commit과 tag를 만들고, 그 tag 기준으로 `Package`
-workflow를 실행합니다. branch protection이 `main` 직접 push를 막는 경우에는
-로컬 helper를 사용하거나 release 규칙을 먼저 조정해야 합니다.
+릴리스/게시 방법, release helper, Trusted Publishing 설정은 `nuget/README.md`에
+모아서 정리해두었습니다. 자세한 앱/드라이버 동작 방식도 같은 문서에서 확인하세요.
 
 ## 이 저장소 빌드
 

--- a/nuget/README.md
+++ b/nuget/README.md
@@ -1,100 +1,23 @@
 # crtsys NuGet Package
 
-`crtsys` provides C/C++ runtime support for Windows kernel-mode drivers. It is
-meant for driver projects that want a controlled subset of MSVC C++ runtime,
-CRT/STL support, and small NTL C++ helper APIs while staying inside the WDK
-driver model.
+`crtsys` is a lightweight C/C++ runtime + helper set for Windows kernel drivers.
+It brings managed access to selected MSVC/C++ runtime, CRT/STL style APIs, and
+NTL abstractions so WDK driver code can be written in a more natural C++ flow.
 
-Use it when you want to write WDK driver control paths in a more familiar C++
-style: driver entry/unload setup, device object management, IOCTL/RPC handling,
-worker-thread coordination, ownership cleanup, error handling, and companion
-app communication. These paths should normally run at `PASSIVE_LEVEL`, with
-selected `APC_LEVEL` use only where the underlying WDK APIs allow it.
+This NuGet package is for **Visual Studio/MSBuild** consumers (`crtsys.<version>.nupkg`).
+It is not a CMake package.
 
-This NuGet package is the Visual Studio/MSBuild distribution of `crtsys`.
-User-mode applications can consume the public NTL headers for companion tools
-such as RPC clients. WDK driver projects can also consume the prebuilt
-`crtsys.lib` and `Ldk.lib` driver libraries.
-
-The package includes:
-
-- public NTL headers and internal compatibility headers
-- native MSBuild `.props` and `.targets` files
-- prebuilt `crtsys.lib` and `Ldk.lib` driver libraries for x64 and ARM64
-- repository documentation for local reference
-
-Installing this package into a normal C++ application project keeps it in
-header-only app mode. Installing it into an existing WDK kernel-mode driver
-project enables driver support automatically. It does not convert a normal C++
-project, console application, static library, or CMake project into a WDK driver
-project, and it does not provide the WDK toolset itself.
-
-For CMake usage, design notes, full API documentation, and tested feature
-coverage, use the repository documentation:
-
-- Repository: <https://github.com/ntoskrnl7/crtsys>
-- CMake quick start: <https://github.com/ntoskrnl7/crtsys#quick-start>
-- Design model: <https://github.com/ntoskrnl7/crtsys/blob/main/docs/design-rationale.md>
-- NTL API reference: <https://github.com/ntoskrnl7/crtsys/blob/main/docs/ntl-api.md>
-- NTL usage examples: <https://github.com/ntoskrnl7/crtsys/blob/main/docs/usage-examples.md>
-
-GitHub Releases also attach this `.nupkg` for offline NuGet installs and a
-native zip with headers, docs, CMake helpers, native MSBuild imports, and
-prebuilt x64/ARM64 Debug/Release driver libraries.
-
-## Install
-
-Create or open a Visual Studio project, then install the package into that
-project:
+## Quick start (MSBuild)
 
 ```powershell
 Install-Package crtsys
 ```
 
-For application projects, the package adds the `crtsys` include path and C++
-compatibility options only. It does not add driver libraries or a driver entry
-point.
+- App projects get compatibility headers/includes.
+- Driver projects (WDK) get automatic WDK linkage for
+  `crtsys.lib` / `Ldk.lib` (x64/ARM64).
 
-For WDK driver projects, the project is still responsible for the kernel-mode
-platform toolset, target SDK/WDK, driver type, WDK include paths, WDK libraries,
-signing, INF, and packaging settings. The `crtsys` package imports native
-MSBuild props/targets automatically and adds the `crtsys` include paths, forced
-include setup, preprocessor definitions, library path, `crtsys.lib`, `Ldk.lib`,
-`libcntpr.lib`, `/FORCE:MULTIPLE`, and the `CrtSysDriverEntry` entry point for
-the default `ntl::main` flow. Debug projects use the package's Debug driver
-libraries, and Release projects use the Release driver libraries. You can
-override that selection with `CrtSysLibraryConfiguration` when needed.
-
-The package also mirrors the repository CMake driver setup for the parts that
-matter to `crtsys`: it disables the WDK `/kernel` compiler switch and puts the
-Visual C++ / Windows SDK include paths before inherited WDK `km\crt` include
-paths. This is required for the C++ runtime and STL headers that `crtsys`
-supports.
-
-Driver builds may emit `LNK4088` because `crtsys` intentionally uses
-`/FORCE:MULTIPLE` for known duplicate CRT/runtime symbols between `libcntpr`,
-`Ldk`, `ntoskrnl`, and the runtime glue. Treat that as an expected build
-warning only when the remaining link output contains no unresolved symbols and
-the duplicate symbols are in the known runtime boundary. Final drivers still
-need load, verifier, signing, and target-OS validation.
-
-Driver support is enabled automatically when MSBuild sees a driver project
-(`ConfigurationType=Driver` or `DriverType` is set). If you need to override
-that detection, set `CrtSysUseDriverSupport=true` or `false` in your project
-before importing the package props.
-
-## Supported Binary Package Target
-
-- Visual Studio 2022
-- Windows SDK/WDK `10.0.22621.0`
-- app header checks on `x86`, `x64`, and `ARM64`
-- driver libraries on `x64` and `ARM64`
-- Debug/Release `crtsys.lib` and `Ldk.lib`
-- `ntl::main` entry point flow
-
-Win32/x86 binaries are not included.
-
-## Minimal Driver Entry
+Example (driver entry concept):
 
 ```cpp
 #include <ntl/driver>
@@ -107,24 +30,24 @@ ntl::status ntl::main(ntl::driver& driver,
 }
 ```
 
-## Minimal App Usage
+This package does not install the WDK/SDK itself and does not convert a normal C++
+project into a driver project.
 
-```cpp
-#include <ntl/rpc/client>
+## Contents
 
-int main() {
-  ntl::rpc::client client(L"test_rpc");
-  return 0;
-}
-```
+- `include/` headers
+- native MSBuild props/targets (`nuget/build/native`)
+- prebuilt libs:
+  `lib/native/{x64,ARM64}/{Debug,Release}/(crtsys.lib|Ldk.lib)`
 
-For an app/driver RPC skeleton and a raw `DeviceIoControl` skeleton, see the
-repository usage examples.
+## Release artifacts (same version, not NuGet)
 
-## Notes
+GitHub Release publishes these in addition to the `.nupkg`:
 
-- `crtsys` is primarily designed for `PASSIVE_LEVEL` driver control paths.
-- Validate your final driver with the Windows, WDK, SDK, Visual Studio,
-  architecture, Driver Verifier, and code integrity settings that you ship.
-- The `.nupkg` also contains the repository `docs` directory for local
-  reference after installation.
+- `crtsys-<version>-prebuilt.zip`
+- `crtsys-<version>-SHA256SUMS.txt`
+
+These two are release-only artifacts and are **not part of the NuGet package**.
+
+For full release workflow, CMake distribution, and API usage details, see:
+- <https://github.com/ntoskrnl7/crtsys/blob/main/README.md>

--- a/scripts/nuget/Build-CrtSysNuGetLibs.ps1
+++ b/scripts/nuget/Build-CrtSysNuGetLibs.ps1
@@ -57,14 +57,31 @@ foreach ($arch in $Architecture) {
       throw "CMake build failed with exit code $LASTEXITCODE."
     }
 
+    # Pick deterministic output paths first, then fallback to recursive search.
+    $archLower = $arch.ToLower()
     $crtsysCandidates = @()
-    $releaseOutput = Join-Path $repoRoot "lib\$arch\crtsys.lib"
-    if ($config -eq 'Release' -and (Test-Path $releaseOutput)) {
-      $crtsysCandidates += Get-Item -Path $releaseOutput
+    $preferredLibPaths = @(
+      Join-Path $repoRoot "lib\$arch\crtsys.lib"
+      Join-Path $repoRoot "lib\$archLower\crtsys.lib"
+    )
+    foreach ($libPath in $preferredLibPaths | Select-Object -Unique) {
+      if (Test-Path $libPath) {
+        $crtsysCandidates += Get-Item -Path $libPath
+        break
+      }
     }
-    $crtsysCandidates += @(Get-ChildItem -Path $buildDir -Filter 'crtsys.lib' -Recurse -File | Sort-Object FullName)
+
     if ($crtsysCandidates.Count -eq 0) {
-      throw "crtsys.lib was not found for $arch $config under $buildDir."
+      $crtsysCandidates = @(
+        Get-ChildItem -Path $buildDir -Filter 'crtsys.lib' -Recurse -File |
+          Sort-Object FullName
+      )
+    }
+    if ($crtsysCandidates.Count -eq 0) {
+      $available = Get-ChildItem -Path $buildDir -Filter '*.lib' -Recurse -File |
+        Where-Object { $_.Name -in @('crtsys.lib', 'Ldk.lib') } |
+        ForEach-Object { $_.FullName }
+      throw "crtsys.lib was not found for $arch $config under $buildDir or $repoRoot\lib. Available libs: $($available -join ', ')"
     }
 
     $ldkCandidates = @(Get-ChildItem -Path $buildDir -Filter 'Ldk.lib' -Recurse -File | Sort-Object FullName)

--- a/scripts/nuget/Pack-CrtSysReleaseAssets.ps1
+++ b/scripts/nuget/Pack-CrtSysReleaseAssets.ps1
@@ -20,7 +20,7 @@ $nugetDirectory = Join-Path $repoRoot 'artifacts\nuget'
 $stagingDirectory = Join-Path $repoRoot 'artifacts\nuget-staging'
 $workDirectory = Join-Path $repoRoot 'artifacts\release-staging'
 $bundleRoot = Join-Path $workDirectory "crtsys-$Version"
-$nativeZipPath = Join-Path $OutputDirectory "crtsys-$Version-native.zip"
+$prebuiltZipPath = Join-Path $OutputDirectory "crtsys-$Version-prebuilt.zip"
 $checksumPath = Join-Path $OutputDirectory "crtsys-$Version-SHA256SUMS.txt"
 $packagePath = Join-Path $nugetDirectory "crtsys.$Version.nupkg"
 $releasePackagePath = Join-Path $OutputDirectory "crtsys.$Version.nupkg"
@@ -51,11 +51,10 @@ Copy-Item -Path (Join-Path $repoRoot 'include') -Destination (Join-Path $bundleR
 Copy-Item -Path (Join-Path $repoRoot 'cmake') -Destination (Join-Path $bundleRoot 'cmake') -Recurse -Force
 Copy-Item -Path (Join-Path $repoRoot 'nuget\build') -Destination (Join-Path $bundleRoot 'build') -Recurse -Force
 Copy-Item -Path (Join-Path $stagingDirectory 'lib') -Destination (Join-Path $bundleRoot 'lib') -Recurse -Force
-
 $bundleReadme = @"
-# crtsys $Version Native Release Bundle
+# crtsys $Version Prebuilt Release Bundle
 
-This archive is an offline-friendly native bundle built by the GitHub Actions
+This archive is an offline-friendly prebuilt bundle built by the GitHub Actions
 Package workflow.
 
 Contents:
@@ -76,14 +75,14 @@ Release is usually the easiest offline install path.
 "@
 Set-Content -LiteralPath (Join-Path $bundleRoot 'README.release.md') -Value $bundleReadme -Encoding UTF8
 
-Remove-Item -Force -Path $nativeZipPath -ErrorAction SilentlyContinue
+Remove-Item -Force -Path $prebuiltZipPath -ErrorAction SilentlyContinue
 Remove-Item -Force -Path $releasePackagePath -ErrorAction SilentlyContinue
 Remove-Item -Force -Path $checksumPath -ErrorAction SilentlyContinue
 
-Compress-Archive -Path $bundleRoot -DestinationPath $nativeZipPath -CompressionLevel Optimal
+Compress-Archive -Path $bundleRoot -DestinationPath $prebuiltZipPath -CompressionLevel Optimal
 Copy-Item -Path $packagePath -Destination $releasePackagePath -Force
 
-Get-FileHash -Algorithm SHA256 -Path $nativeZipPath, $releasePackagePath |
+Get-FileHash -Algorithm SHA256 -Path $prebuiltZipPath, $releasePackagePath |
   ForEach-Object { "$($_.Hash.ToLowerInvariant())  $([System.IO.Path]::GetFileName($_.Path))" } |
   Set-Content -LiteralPath $checksumPath -Encoding ASCII
 

--- a/scripts/nuget/Test-CrtSysReleaseAssets.ps1
+++ b/scripts/nuget/Test-CrtSysReleaseAssets.ps1
@@ -29,9 +29,9 @@ if ([string]::IsNullOrWhiteSpace($WorkDirectory)) {
 }
 
 $ReleaseDirectory = (Resolve-Path $ReleaseDirectory).Path
-$nativeZipPath = Join-Path $ReleaseDirectory "crtsys-$Version-native.zip"
-if (-not (Test-Path $nativeZipPath)) {
-  throw "Native release zip was not found: $nativeZipPath"
+$prebuiltZipPath = Join-Path $ReleaseDirectory "crtsys-$Version-prebuilt.zip"
+if (-not (Test-Path $prebuiltZipPath)) {
+  throw "Prebuilt release zip was not found: $prebuiltZipPath"
 }
 
 $platformByArchitecture = @{
@@ -43,8 +43,8 @@ $platform = $platformByArchitecture[$Architecture]
 Remove-Item -Recurse -Force -Path $WorkDirectory -ErrorAction SilentlyContinue
 New-Item -ItemType Directory -Force -Path $WorkDirectory | Out-Null
 
-$unpackDirectory = Join-Path $WorkDirectory 'native'
-Expand-Archive -Path $nativeZipPath -DestinationPath $unpackDirectory -Force
+$unpackDirectory = Join-Path $WorkDirectory 'prebuilt'
+Expand-Archive -Path $prebuiltZipPath -DestinationPath $unpackDirectory -Force
 
 $bundleRoot = Join-Path $unpackDirectory "crtsys-$Version"
 if (-not (Test-Path (Join-Path $bundleRoot 'cmake\CrtSys.cmake'))) {
@@ -58,7 +58,7 @@ if (-not (Test-Path (Join-Path $bundleRoot 'cmake\CrtSys.cmake'))) {
 }
 
 if ([string]::IsNullOrWhiteSpace($bundleRoot) -or -not (Test-Path (Join-Path $bundleRoot 'cmake\CrtSys.cmake'))) {
-  throw "Unpacked native release bundle does not contain cmake\CrtSys.cmake."
+  throw "Unpacked prebuilt release bundle does not contain cmake\CrtSys.cmake."
 }
 
 foreach ($requiredPath in @(
@@ -69,7 +69,7 @@ foreach ($requiredPath in @(
 )) {
   $fullPath = Join-Path $bundleRoot $requiredPath
   if (-not (Test-Path $fullPath)) {
-    throw "Native release bundle is missing expected file: $fullPath"
+    throw "Prebuilt release bundle is missing expected file: $fullPath"
   }
 }
 
@@ -120,13 +120,13 @@ $configureArgs = @(
   "-DCMAKE_VS_WINDOWS_TARGET_PLATFORM_VERSION=$WindowsSdkVersion"
 )
 
-Write-Host "Configuring native release asset consumer for $Architecture $Configuration"
+Write-Host "Configuring prebuilt release asset consumer for $Architecture $Configuration"
 & cmake @configureArgs
 if ($LASTEXITCODE -ne 0) {
   throw "CMake configure failed with exit code $LASTEXITCODE."
 }
 
-Write-Host "Building native release asset consumer for $Architecture $Configuration"
+Write-Host "Building prebuilt release asset consumer for $Architecture $Configuration"
 & cmake --build $buildDirectory --config $Configuration --target crtsys_release_asset_smoke --parallel
 if ($LASTEXITCODE -ne 0) {
   throw "CMake build failed with exit code $LASTEXITCODE."
@@ -134,7 +134,7 @@ if ($LASTEXITCODE -ne 0) {
 
 $driverPath = Join-Path $buildDirectory "$Configuration\crtsys_release_asset_smoke.sys"
 if (-not (Test-Path $driverPath)) {
-  throw "Native release asset consumer driver was not produced: $driverPath"
+  throw "Prebuilt release asset consumer driver was not produced: $driverPath"
 }
 
-Write-Host "Native release asset consumer test passed: $driverPath"
+Write-Host "Prebuilt release asset consumer test passed: $driverPath"


### PR DESCRIPTION
## Summary
- Align naming in CI and docs for GitHub release vs NuGet package artifacts.
- Rename release bundle files from `native` to `prebuilt` and make release naming consistent.
- Simplify and clarify NuGet README while keeping it concise for package consumers.
- Improve root and docs/ko-kr release docs to match the updated artifact names.
- Fix NuGet/packaging scripts (`Build-CrtSysNuGetLibs`, `Pack-CrtSysReleaseAssets`, `Test-CrtSysReleaseAssets`) to match release naming and packaging behavior.

## Files changed
- `.github/workflows/package.yml`
- `README.md`
- `docs/ko-kr.md`
- `nuget/README.md`
- `scripts/nuget/Build-CrtSysNuGetLibs.ps1`
- `scripts/nuget/Pack-CrtSysReleaseAssets.ps1`
- `scripts/nuget/Test-CrtSysReleaseAssets.ps1`

## Testing
- CI/manual workflow runs were previously executed after the preceding refactors; this PR contains only naming/docs packaging clean-up changes on top of the passing branch.