### PR TITLE
chore: improve NuGet README examples for IOCTL/RPC consumer usage

### DIFF
--- a/nuget/README.md
+++ b/nuget/README.md
@@ -5,9 +5,8 @@ It brings managed access to selected MSVC/C++ runtime, CRT/STL style APIs, and
 NTL abstractions so WDK driver code can be written in a more natural C++ flow.
 
 This NuGet package is for **Visual Studio/MSBuild** consumers (`crtsys.<version>.nupkg`).
-It is not a CMake package.
 
-## Quick start (MSBuild)
+## Quick start
 
 ```powershell
 Install-Package crtsys
@@ -17,7 +16,15 @@ Install-Package crtsys
 - Driver projects (WDK) get automatic WDK linkage for
   `crtsys.lib` / `Ldk.lib` (x64/ARM64).
 
-Example (driver entry concept):
+What this NuGet package is for:
+
+- Modern C++ ownership for control-plane code (`ntl::driver`, `ntl::device`,
+  unload callback)
+- Small, readable status/error flow with `ntl::status`
+- Shared user↔kernel contracts from a single header source (`shared/*.hpp`)
+- Reliable RAII-style lifecycle for driver resources and cleanup
+
+Example (minimal driver entry):
 
 ```cpp
 #include <ntl/driver>
@@ -27,6 +34,162 @@ ntl::status ntl::main(ntl::driver& driver,
   (void)registry_path;
   driver.on_unload([]() {});
   return ntl::status::ok();
+}
+```
+
+### IOCTL sample (kernel + app pair)
+
+Shared header (`shared/demo_ioctl.hpp`):
+
+```cpp
+// shared/demo_ioctl.hpp
+#pragma once
+
+#define DEMO_DEVICE_NAME L"demo_device"
+#define DEMO_IOCTL_ECHO \
+  CTL_CODE(FILE_DEVICE_UNKNOWN, 0x801, METHOD_BUFFERED, FILE_ANY_ACCESS)
+```
+
+Kernel side:
+
+```cpp
+#include <string>
+#include <wdm.h>
+#include <ntl/driver>
+#include "shared/demo_ioctl.hpp" // DEMO_DEVICE_NAME/DEMO_IOCTL_*
+
+ntl::status ntl::main(ntl::driver& driver,
+                      const std::wstring& registry_path) {
+  (void)registry_path;
+
+  auto options = ntl::device_options()
+    .name(DEMO_DEVICE_NAME)
+    .type(FILE_DEVICE_UNKNOWN)
+    .exclusive(false);
+
+  auto device = driver.create_device<void>(options);
+  device->on_device_control([](const ntl::device_control::code& code,
+                               const ntl::device_control::in_buffer& in,
+                               ntl::device_control::out_buffer& out) {
+    // register IRP_MJ_DEVICE_CONTROL logic without switch-heavy boilerplate
+    if (code == DEMO_IOCTL_ECHO && in.ptr && out.ptr) {
+      const auto bytes = in.size < out.size ? in.size : out.size;
+      RtlCopyMemory(out.ptr, in.ptr, bytes);
+      out.size = bytes;
+    }
+  });
+
+  driver.on_unload([device]() mutable {
+    // keep cleanup in one place; shared_ptr reset happens on unload
+    device.reset();
+  });
+
+  return ntl::status::ok();
+}
+```
+
+App side:
+
+```cpp
+#define WIN32_LEAN_AND_MEAN
+#include <windows.h>
+#include <winioctl.h>
+#include <iostream>
+#include "shared/demo_ioctl.hpp"
+
+int wmain() {
+  const HANDLE device = CreateFileW(
+      L"\\\\?\\Global\\GLOBALROOT\\Device\\" DEMO_DEVICE_NAME,
+      GENERIC_READ | GENERIC_WRITE,
+      0, nullptr, OPEN_EXISTING, 0, nullptr);
+
+  if (device == INVALID_HANDLE_VALUE) {
+    std::cerr << "failed to open device\n";
+    return 1;
+  }
+
+  char request[] = "hello";
+  char reply[sizeof request] = {};
+  DWORD returned = 0;
+  const BOOL ok = DeviceIoControl(device,
+                                  DEMO_IOCTL_ECHO,
+                                  request,
+                                  static_cast<DWORD>(sizeof request),
+                                  reply,
+                                  static_cast<DWORD>(sizeof reply),
+                                  &returned,
+                                  nullptr);
+  CloseHandle(device);
+  if (!ok) {
+    std::cerr << "DeviceIoControl failed\n";
+    return 1;
+  }
+  return 0;
+}
+```
+
+### RPC sample (kernel + app pair)
+
+Shared header (`shared/demo_rpc.hpp`):
+
+```cpp
+// shared/demo_rpc.hpp
+#pragma once
+
+NTL_RPC_BEGIN(demo_rpc)
+
+NTL_ADD_CALLBACK_2(demo_rpc, int, add, int, a, int, b, {
+  return a + b;
+})
+
+NTL_ADD_CALLBACK_1(demo_rpc, int, negate, int, value, {
+  return -value;
+})
+
+NTL_RPC_END(demo_rpc)
+```
+
+Kernel side:
+
+```cpp
+#include <memory>
+#include <ntl/driver>
+#include <ntl/rpc/server>
+#include "shared/demo_rpc.hpp" // generated RPC contract header
+
+ntl::status ntl::main(ntl::driver& driver,
+                      const std::wstring& registry_path) {
+  (void)registry_path;
+
+  auto rpc_server = demo_rpc::init(driver); // creates \\Device\\demo_rpc endpoint
+
+  driver.on_unload([rpc_server]() mutable {
+    rpc_server.reset(); // remove endpoint before driver unload completes
+  });
+
+  return ntl::status::ok();
+}
+```
+
+App side:
+
+```cpp
+#include <exception>
+#include <iostream>
+#include <ntl/rpc/client>
+#include "shared/demo_rpc.hpp" // same shared contract header
+
+int wmain() {
+  try {
+    std::wcout << L"40 + 2 = " << demo_rpc::add(40, 2) << L"\n";
+    ntl::rpc::client client(L"demo_rpc");
+    auto value = client.invoke<int>(demo_rpc::negate_1_index, 7);
+    std::wcout << L"negate(7) = " << value << L"\n";
+  } catch (const std::exception& e) {
+    std::cerr << "RPC call failed: " << e.what() << "\n";
+    return 1;
+  }
+  return 0;
 }
 ```
 
@@ -40,14 +203,13 @@ project into a driver project.
 - prebuilt libs:
   `lib/native/{x64,ARM64}/{Debug,Release}/(crtsys.lib|Ldk.lib)`
 
-## Release artifacts (same version, not NuGet)
+## Release artifacts
 
-GitHub Release publishes these in addition to the `.nupkg`:
+- `crtsys-<version>-prebuilt.zip`  
+  A prebuilt bundle containing headers, libraries, documentation, and CMake helpers.
+  It includes `CrtSys.cmake` for CMake-based consumers, and also carries the same native MSBuild build support files.
+- `crtsys-<version>-SHA256SUMS.txt`  
+  Checksum file for offline/manual verification.
 
-- `crtsys-<version>-prebuilt.zip`
-- `crtsys-<version>-SHA256SUMS.txt`
-
-These two are release-only artifacts and are **not part of the NuGet package**.
-
-For full release workflow, CMake distribution, and API usage details, see:
+For full package usage, release details, and API reference, see:
 - <https://github.com/ntoskrnl7/crtsys/blob/main/README.md>


### PR DESCRIPTION
## Summary
- Improve NuGet package README to remove outdated wording and align with NuGet/MSBuild usage.
- Add practical IOCTL and RPC sample pairs for kernel and app sides.
- Add shared contract header snippets for the examples (shared/demo_ioctl.hpp, shared/demo_rpc.hpp).
- Keep package description concise and include release artifact notes.