### PR TITLE
Fix NuGet driver support when props import early

### DIFF
--- a/nuget/build/native/crtsys.props
+++ b/nuget/build/native/crtsys.props
@@ -2,29 +2,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <CrtSysRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', '..', '..'))</CrtSysRoot>
-    <CrtSysIsDriverProject Condition="'$(ConfigurationType)' == 'Driver' or '$(DriverType)' != ''">true</CrtSysIsDriverProject>
-    <CrtSysUseDriverSupport Condition="'$(CrtSysUseDriverSupport)' == '' and '$(CrtSysIsDriverProject)' == 'true'">true</CrtSysUseDriverSupport>
-    <CrtSysUseDriverSupport Condition="'$(CrtSysUseDriverSupport)' == ''">false</CrtSysUseDriverSupport>
-    <CrtSysLibPlatform Condition="'$(Platform)' == 'Win32'">x86</CrtSysLibPlatform>
-    <CrtSysLibPlatform Condition="'$(CrtSysLibPlatform)' == ''">$(Platform)</CrtSysLibPlatform>
-    <CrtSysLibraryConfiguration Condition="'$(CrtSysLibraryConfiguration)' == '' and ('$(Configuration)' == 'Debug' or '$(Configuration)' == 'Release')">$(Configuration)</CrtSysLibraryConfiguration>
-    <CrtSysLibraryConfiguration Condition="'$(CrtSysLibraryConfiguration)' == ''">Release</CrtSysLibraryConfiguration>
-    <CrtSysLibDir>$(CrtSysRoot)lib\native\$(CrtSysLibPlatform)\$(CrtSysLibraryConfiguration)\</CrtSysLibDir>
-    <CrtSysUseNtlMain Condition="'$(CrtSysUseNtlMain)' == ''">true</CrtSysUseNtlMain>
-    <CrtSysDriverPreprocessorDefinitions>_KERNEL32_;_ITERATOR_DEBUG_LEVEL=0;_HAS_EXCEPTIONS;CRTSYS_USE_LIBCNTPR</CrtSysDriverPreprocessorDefinitions>
-    <CrtSysDriverPreprocessorDefinitions Condition="'$(CrtSysUseNtlMain)' == 'true'">$(CrtSysDriverPreprocessorDefinitions);CRTSYS_USE_NTL_MAIN</CrtSysDriverPreprocessorDefinitions>
-    <DisableKernelFlag Condition="'$(CrtSysUseDriverSupport)' == 'true'">true</DisableKernelFlag>
   </PropertyGroup>
-
-  <ItemDefinitionGroup>
-    <ClCompile>
-      <AdditionalIncludeDirectories Condition="'$(CrtSysUseDriverSupport)' == 'true'">$(CrtSysRoot)include;$(CrtSysRoot)include\.internal\msvc\$(VCToolsVersion);$(CrtSysRoot)include\.internal\msvc\$(PlatformToolsetVersion);$(CrtSysRoot)include\.internal\msvc\$(VCToolsVersion)\stl;$(CrtSysRoot)include\.internal\msvc\$(PlatformToolsetVersion)\stl;$(CrtSysRoot)include\.internal\msvc\143;$(CrtSysRoot)include\.internal\msvc\143\stl;$(CrtSysRoot)include\.internal\msvc\142;$(CrtSysRoot)include\.internal\msvc\142\stl;$(CrtSysRoot)include\.internal\msvc\141;$(CrtSysRoot)include\.internal\msvc\141\stl;$(VC_IncludePath);$(WindowsSDK_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <AdditionalIncludeDirectories Condition="'$(CrtSysUseDriverSupport)' != 'true'">$(CrtSysRoot)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <ForcedIncludeFiles Condition="'$(CrtSysUseDriverSupport)' == 'true'">$(CrtSysRoot)include\.internal\adjust_link_order;%(ForcedIncludeFiles)</ForcedIncludeFiles>
-      <PreprocessorDefinitions Condition="'$(CrtSysUseDriverSupport)' == 'true'">$(CrtSysDriverPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalOptions Condition="'$(CrtSysUseDriverSupport)' == 'true'">/Zc:threadSafeInit- /Zc:__cplusplus /Zc:wchar_t %(AdditionalOptions)</AdditionalOptions>
-      <AdditionalOptions Condition="'$(CrtSysUseDriverSupport)' != 'true'">/Zc:__cplusplus /Zc:wchar_t %(AdditionalOptions)</AdditionalOptions>
-      <RuntimeLibrary Condition="'$(CrtSysUseDriverSupport)' == 'true'">MultiThreaded</RuntimeLibrary>
-    </ClCompile>
-  </ItemDefinitionGroup>
 </Project>

--- a/nuget/build/native/crtsys.targets
+++ b/nuget/build/native/crtsys.targets
@@ -1,5 +1,22 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CrtSysIsDriverProject Condition="'$(CrtSysIsDriverProject)' == '' and ('$(ConfigurationType)' == 'Driver' or '$(DriverType)' != '')">true</CrtSysIsDriverProject>
+    <CrtSysIsDriverProject Condition="'$(CrtSysIsDriverProject)' == ''">false</CrtSysIsDriverProject>
+    <CrtSysUseDriverSupport Condition="'$(CrtSysUseDriverSupport)' == '' and '$(CrtSysIsDriverProject)' == 'true'">true</CrtSysUseDriverSupport>
+    <CrtSysUseDriverSupport Condition="'$(CrtSysUseDriverSupport)' == ''">false</CrtSysUseDriverSupport>
+    <CrtSysLibPlatform Condition="'$(CrtSysLibPlatform)' == '' and '$(Platform)' == 'Win32'">x86</CrtSysLibPlatform>
+    <CrtSysLibPlatform Condition="'$(CrtSysLibPlatform)' == ''">$(Platform)</CrtSysLibPlatform>
+    <CrtSysLibraryConfiguration Condition="'$(CrtSysLibraryConfiguration)' == '' and ('$(Configuration)' == 'Debug' or '$(Configuration)' == 'Release')">$(Configuration)</CrtSysLibraryConfiguration>
+    <CrtSysLibraryConfiguration Condition="'$(CrtSysLibraryConfiguration)' == ''">Release</CrtSysLibraryConfiguration>
+    <CrtSysLibDir Condition="'$(CrtSysLibDir)' == ''">$(CrtSysRoot)lib\native\$(CrtSysLibPlatform)\$(CrtSysLibraryConfiguration)\</CrtSysLibDir>
+    <CrtSysUseNtlMain Condition="'$(CrtSysUseNtlMain)' == ''">true</CrtSysUseNtlMain>
+    <CrtSysDriverPreprocessorDefinitions Condition="'$(CrtSysDriverPreprocessorDefinitions)' == ''">_KERNEL32_;_ITERATOR_DEBUG_LEVEL=0;_HAS_EXCEPTIONS;CRTSYS_USE_LIBCNTPR</CrtSysDriverPreprocessorDefinitions>
+    <CrtSysDriverPreprocessorDefinitions Condition="'$(CrtSysUseNtlMain)' == 'true'">$(CrtSysDriverPreprocessorDefinitions);CRTSYS_USE_NTL_MAIN</CrtSysDriverPreprocessorDefinitions>
+    <DisableKernelFlag Condition="'$(CrtSysUseDriverSupport)' == 'true'">true</DisableKernelFlag>
+    <Inf2CatUseLocalTime Condition="'$(CrtSysUseDriverSupport)' == 'true' and '$(Inf2CatUseLocalTime)' == ''">true</Inf2CatUseLocalTime>
+  </PropertyGroup>
+
   <Target Name="CrtSysValidateNativePackage" BeforeTargets="PrepareForBuild">
     <Error
       Condition="'$(CrtSysUseDriverSupport)' == 'true' and '$(CrtSysUseNtlMain)' != 'true'"
@@ -20,6 +37,16 @@
   </Target>
 
   <ItemDefinitionGroup>
+    <ClCompile>
+      <AdditionalIncludeDirectories Condition="'$(CrtSysUseDriverSupport)' == 'true'">$(CrtSysRoot)include;$(CrtSysRoot)include\.internal\msvc\$(VCToolsVersion);$(CrtSysRoot)include\.internal\msvc\$(PlatformToolsetVersion);$(CrtSysRoot)include\.internal\msvc\$(VCToolsVersion)\stl;$(CrtSysRoot)include\.internal\msvc\$(PlatformToolsetVersion)\stl;$(CrtSysRoot)include\.internal\msvc\143;$(CrtSysRoot)include\.internal\msvc\143\stl;$(CrtSysRoot)include\.internal\msvc\142;$(CrtSysRoot)include\.internal\msvc\142\stl;$(CrtSysRoot)include\.internal\msvc\141;$(CrtSysRoot)include\.internal\msvc\141\stl;$(VC_IncludePath);$(WindowsSDK_IncludePath);%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories Condition="'$(CrtSysUseDriverSupport)' != 'true'">$(CrtSysRoot)include;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <ForcedIncludeFiles Condition="'$(CrtSysUseDriverSupport)' == 'true'">$(CrtSysRoot)include\.internal\adjust_link_order;%(ForcedIncludeFiles)</ForcedIncludeFiles>
+      <PreprocessorDefinitions Condition="'$(CrtSysUseDriverSupport)' == 'true'">$(CrtSysDriverPreprocessorDefinitions);%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <AdditionalOptions Condition="'$(CrtSysUseDriverSupport)' == 'true'">/Zc:threadSafeInit- /Zc:__cplusplus /Zc:wchar_t %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions Condition="'$(CrtSysUseDriverSupport)' != 'true'">/Zc:__cplusplus /Zc:wchar_t %(AdditionalOptions)</AdditionalOptions>
+      <RuntimeLibrary Condition="'$(CrtSysUseDriverSupport)' == 'true'">MultiThreaded</RuntimeLibrary>
+      <ExceptionHandling Condition="'$(CrtSysUseDriverSupport)' == 'true'">Sync</ExceptionHandling>
+    </ClCompile>
     <Link Condition="'$(CrtSysUseDriverSupport)' == 'true'">
       <AdditionalLibraryDirectories>$(CrtSysLibDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>crtsys.lib;Ldk.lib;libcntpr.lib;%(AdditionalDependencies)</AdditionalDependencies>

--- a/scripts/nuget/Test-CrtSysNuGetPackage.ps1
+++ b/scripts/nuget/Test-CrtSysNuGetPackage.ps1
@@ -148,7 +148,6 @@ $nlohmannJsonPackageRoot = $null
   -Version $Version `
   -Source $PackageDirectory `
   -OutputDirectory $packagesDirectory `
-  -ExcludeVersion `
   -NonInteractive `
   -Verbosity detailed
 
@@ -156,7 +155,25 @@ if ($LASTEXITCODE -ne 0) {
   throw "nuget install failed with exit code $LASTEXITCODE."
 }
 
-$packageRoot = Join-Path $packagesDirectory 'crtsys'
+$packageRoot = Join-Path $packagesDirectory "crtsys.$Version"
+if (-not (Test-Path $packageRoot)) {
+  $installedPackageCandidates = @(
+    Get-ChildItem -Path $packagesDirectory -Directory |
+      Where-Object { $_.Name -like 'crtsys.*' } |
+      Sort-Object Name
+  )
+
+  if ($installedPackageCandidates.Count -ne 1) {
+    throw "Expected exactly one installed crtsys package under '$packagesDirectory', found $($installedPackageCandidates.Count)."
+  }
+
+  $packageRoot = $installedPackageCandidates[0].FullName
+}
+
+$packageRoot = (Resolve-Path $packageRoot).Path
+if (-not $packageRoot.EndsWith('\')) {
+  $packageRoot += '\'
+}
 $requiredPackagePaths = @(
   'README.md',
   'build\native\crtsys.props',
@@ -225,6 +242,7 @@ $msbuildArguments = @(
   '/m',
   "/p:Configuration=$Configuration",
   "/p:Platform=$msbuildPlatform",
+  "/p:CrtSysPackageRoot=$packageRoot",
   '/v:minimal'
 )
 if ($isDriverConsumer) {

--- a/test/nuget/crtsys_nuget_app_test.vcxproj
+++ b/test/nuget/crtsys_nuget_app_test.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CrtSysPackageRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
+    <CrtSysPackageRoot Condition="'$(CrtSysPackageRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
   </PropertyGroup>
   <Import Project="$(CrtSysPackageRoot)build\native\crtsys.props" Condition="Exists('$(CrtSysPackageRoot)build\native\crtsys.props')" />
   <ItemGroup Label="ProjectConfigurations">

--- a/test/nuget/crtsys_nuget_app_test.vcxproj
+++ b/test/nuget/crtsys_nuget_app_test.vcxproj
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CrtSysPackageRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
+  </PropertyGroup>
+  <Import Project="$(CrtSysPackageRoot)build\native\crtsys.props" Condition="Exists('$(CrtSysPackageRoot)build\native\crtsys.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -47,12 +51,10 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <CrtSysPackageRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
     <TargetName>crtsys_nuget_app_test</TargetName>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="Exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
-    <Import Project="$(CrtSysPackageRoot)build\native\crtsys.props" Condition="Exists('$(CrtSysPackageRoot)build\native\crtsys.props')" />
   </ImportGroup>
   <ItemDefinitionGroup>
     <ClCompile>

--- a/test/nuget/crtsys_nuget_test.vcxproj
+++ b/test/nuget/crtsys_nuget_test.vcxproj
@@ -1,5 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <CrtSysPackageRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
+  </PropertyGroup>
+  <Import Project="$(CrtSysPackageRoot)build\native\crtsys.props" Condition="Exists('$(CrtSysPackageRoot)build\native\crtsys.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
       <Configuration>Debug</Configuration>
@@ -45,13 +49,11 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
   <PropertyGroup>
-    <CrtSysPackageRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
     <NlohmannJsonPackageRoot Condition="'$(NlohmannJsonPackageRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'nlohmann.json'))</NlohmannJsonPackageRoot>
     <TargetName>crtsys_nuget_test</TargetName>
   </PropertyGroup>
   <ImportGroup Label="PropertySheets">
     <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="Exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" />
-    <Import Project="$(CrtSysPackageRoot)build\native\crtsys.props" Condition="Exists('$(CrtSysPackageRoot)build\native\crtsys.props')" />
   </ImportGroup>
   <ItemGroup Label="WrappedTaskItems" />
   <ItemDefinitionGroup>
@@ -61,7 +63,6 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <AdditionalIncludeDirectories>$(MSBuildThisFileDirectory);$(MSBuildThisFileDirectory)..\cmake;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>CRTSYS_TEST_NO_BREAKPOINT;CRTSYS_TEST_NLOHMANN_JSON;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <ExceptionHandling>Sync</ExceptionHandling>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/test/nuget/crtsys_nuget_test.vcxproj
+++ b/test/nuget/crtsys_nuget_test.vcxproj
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
-    <CrtSysPackageRoot>$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
+    <CrtSysPackageRoot Condition="'$(CrtSysPackageRoot)' == ''">$([MSBuild]::NormalizeDirectory('$(MSBuildThisFileDirectory)', 'packages', 'crtsys'))</CrtSysPackageRoot>
   </PropertyGroup>
   <Import Project="$(CrtSysPackageRoot)build\native\crtsys.props" Condition="Exists('$(CrtSysPackageRoot)build\native\crtsys.props')" />
   <ItemGroup Label="ProjectConfigurations">


### PR DESCRIPTION
## Summary
- move driver/app mode defaults from `crtsys.props` into `crtsys.targets` so driver support is evaluated after WDK project configuration is available
- have the package provide driver exception handling and Inf2Cat local-time defaults
- update both NuGet consumer tests to import `crtsys.props` early, matching the problematic packages.config/native NuGet import shape
- update `Test-CrtSysNuGetPackage.ps1` to install `crtsys` into the default versioned `packages/crtsys.<version>` folder and pass that installed package root into MSBuild
- update the driver consumer test to rely on the package for `/EHsc`

## Validation
- XML parsed for `crtsys.props`, `crtsys.targets`, `crtsys_nuget_test.vcxproj`, and `crtsys_nuget_app_test.vcxproj`
- PowerShell parsed for `Test-CrtSysNuGetPackage.ps1`
- `git diff --check`
- manual MSBuild driver repro using a copied WDK driver project with early `crtsys.props` import and no consumer-side `/EHsc` or `Inf2CatUseLocalTime` workaround:
  `MSBuild.exe MyDriver1.vcxproj /t:Rebuild /m:1 /p:Configuration=Debug /p:Platform=x64 /p:SignMode=Off /v:minimal`
- NuGet app consumer builds with early `crtsys.props` import and a versioned `CrtSysPackageRoot` path:
  - `Debug|x64`
  - `Release|x64`
  - `Debug|Win32`
  - `Debug|ARM64`

Notes: the manual driver repro produced `MyDriver1.sys` and a catalog with Inf2Cat signability errors/warnings reported as `None`. The app builds stayed in `header-only app mode` with `CrtSysUseDriverSupport=false`.