### PR TITLE
test(nuget): add EXPECT_GT to gtest shim

### DIFF
--- a/test/nuget/gtest/gtest.h
+++ b/test/nuget/gtest/gtest.h
@@ -117,6 +117,16 @@ inline int RunAllTests() {
     }                                                                         \
   } while (false)
 
+#define EXPECT_GT(actual, expected)                                           \
+  do {                                                                        \
+    const auto& actual_value = (actual);                                      \
+    const auto& expected_value = (expected);                                  \
+    if (!(actual_value > expected_value)) {                                   \
+      ::testing::record_failure(__FILE__, __LINE__,                           \
+                                "EXPECT_GT(" #actual ", " #expected ")");   \
+    }                                                                         \
+  } while (false)
+
 #define EXPECT_STREQ(actual, expected)                                        \
   do {                                                                        \
     const auto* actual_value = (actual);                                      \


### PR DESCRIPTION
## Summary
- Add EXPECT_GT to the small gtest compatibility header used by NuGet consumer tests.
- Fix app consumer builds after test/cmake/app/src/main.cpp started checking create_count > close_count.

## Testing
- Not run locally; this targets the GitHub Actions Windows NuGet app consumer failure from run 27781768274.
